### PR TITLE
fix: unbreak fresh installs (migration order + entrypoint error handling)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,119 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+  NEXT_TELEMETRY_DISABLED: "1"
+
+jobs:
+  migrations:
+    name: Migrations apply to an empty database
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: dnastudio
+          POSTGRES_USER: dnastudio
+          POSTGRES_PASSWORD: dnastudio
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U dnastudio"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql://dnastudio:dnastudio@localhost:5432/dnastudio
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+
+      # Regression test for #8: migrations are applied in lexicographic order of
+      # their directory name, so a badly named migration can run before the one
+      # that creates the tables it touches. That broke every fresh install and
+      # nothing caught it. This job is what catches it now.
+      - name: Apply migrations to an empty database
+        run: npx prisma migrate deploy
+
+      - name: No migrations left pending
+        run: npx prisma migrate status
+
+      - name: Migrated schema matches schema.prisma
+        run: |
+          npx prisma migrate diff \
+            --from-url "$DATABASE_URL" \
+            --to-schema-datamodel prisma/schema.prisma \
+            --exit-code
+
+  entrypoint:
+    name: Container entrypoint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Regression test for #9: transient database failures are retried, a
+      # bounded number of times; deterministic ones abort with the real error.
+      - run: sh docker/entrypoint.test.sh
+
+  build:
+    name: Lint, typecheck, build
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgresql://dnastudio:dnastudio@localhost:5432/dnastudio
+      NEXTAUTH_SECRET: placeholder-for-ci-only
+      NEXTAUTH_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npx tsc --noEmit
+      - run: npm run build
+
+  compose:
+    name: docker compose up (end to end)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and start the stack
+        run: docker compose up -d --build app
+
+      - name: Wait for the app to report healthy
+        run: |
+          container="$(docker compose ps -q app)"
+          for _ in $(seq 1 60); do
+            status="$(docker inspect --format '{{.State.Health.Status}}' "$container" 2>/dev/null || echo unknown)"
+            echo "health: $status"
+            case "$status" in
+              healthy) exit 0 ;;
+              unhealthy) echo "app reported unhealthy"; exit 1 ;;
+            esac
+            sleep 5
+          done
+          echo "app never became healthy"
+          exit 1
+
+      - name: Every migration is applied
+        run: |
+          docker compose exec -T app \
+            node node_modules/prisma/build/index.js migrate status
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose logs --no-color
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,11 @@ src/
    npm run build
    ```
 
+   If you touched `docker/entrypoint.sh`, also run its tests:
+   ```bash
+   sh docker/entrypoint.test.sh
+   ```
+
 6. **Commit with clear messages** — describe what and why, not how
 
 7. **Open a PR** against `main`
@@ -103,8 +108,36 @@ src/
 ## Database Changes
 
 - Add fields to `prisma/schema.prisma`
-- Create a migration file in `prisma/migrations/YYYYMMDD_description/migration.sql`
+- Create a migration file in `prisma/migrations/<name>/migration.sql`
 - Run `npx prisma generate` to update the client
+
+### Migration naming
+
+Prisma applies migrations in **lexicographic order of the directory name** — not
+by date, not by creation time. A migration whose name sorts before an earlier one
+will run before it, against a schema that does not exist yet.
+
+This has already broken the project once ([#8](https://github.com/moesaif/dna-studio/issues/8)):
+`20260317_add_settings_suggestions` sorted ahead of `20260317_init` because
+`"a" < "i"`, so an `ALTER TABLE` ran before the table was created — and every
+fresh install failed to migrate for months.
+
+So:
+
+- **Do not reuse a date prefix another migration already uses** unless the new
+  name also sorts after it. Appending a letter — `20260317b_add_something` — is
+  the safest way to add a second migration to a date that is already taken.
+- A full timestamp such as `20260317120000_add_something` does **not** fix this:
+  digits sort before `_` (`0x31` < `0x5F`), so it still lands ahead of
+  `20260317_init`.
+- **Do not rename or edit a migration that has already shipped.** Prisma
+  checksums each file and records the directory name in `_prisma_migrations`;
+  changing either breaks databases that already applied it. If a rename is
+  genuinely unavoidable, make the SQL idempotent (`ADD COLUMN IF NOT EXISTS`)
+  so re-applying it under the new name is a no-op.
+
+CI applies every migration to an empty database on each pull request, so an
+ordering mistake fails the build rather than shipping.
 
 ## Reporting Issues
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
 COPY --from=builder /app/node_modules/playwright ./node_modules/playwright
 COPY --from=builder /app/node_modules/playwright-core ./node_modules/playwright-core
+COPY --chown=nextjs:nodejs docker/entrypoint.sh ./docker/entrypoint.sh
 
 RUN chown -R nextjs:nodejs node_modules/@prisma node_modules/prisma
 
@@ -57,4 +58,9 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["sh", "-c", "until node node_modules/prisma/build/index.js migrate deploy; do echo 'Database not ready, retrying in 5s...'; sleep 5; done && node server.js"]
+# Reports unhealthy — rather than a misleading "Up" — when the app cannot serve
+# requests or cannot reach the database.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
+  CMD wget -q -O /dev/null http://127.0.0.1:3000/api/health || exit 1
+
+CMD ["/app/docker/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,62 @@ All configuration is done via environment variables. See [`.env.example`](.env.e
 | `GOOGLE_API_KEY` | Google API key (if using Gemini) | Conditional |
 | `OLLAMA_BASE_URL` | Ollama server URL (if using local models) | Conditional |
 
+## Troubleshooting
+
+### Is it running?
+
+The app exposes a health endpoint, which the container healthcheck uses:
+
+```bash
+curl http://localhost:3000/api/health
+# {"status":"ok","database":"reachable"}
+```
+
+`docker compose ps` reports the app as `healthy` only once it is serving
+requests *and* can reach the database.
+
+### The app container keeps restarting
+
+Read the logs — the app prints the underlying Prisma error and exits, rather
+than retrying a failure that cannot succeed:
+
+```bash
+docker compose logs app
+```
+
+Genuine "the database is not up yet" failures are retried (10 attempts, 5s
+apart — tune with `MIGRATE_MAX_ATTEMPTS` and `MIGRATE_RETRY_DELAY`). Anything
+else stops the container with the real error.
+
+### `P3009: migrate found failed migrations in the target database`
+
+A migration is recorded as failed, which blocks every migration after it.
+
+Releases before this fix shipped a migration ordering bug ([#8](https://github.com/moesaif/dna-studio/issues/8))
+that put **every** fresh install into this state, so if you tried DNA Studio
+earlier and it never came up, this is why.
+
+Inspect the history:
+
+```bash
+docker compose exec app node node_modules/prisma/build/index.js migrate status
+```
+
+Postgres rolls a failed migration back, so the failed entry almost always
+represents no schema change at all. Clear it and let migrations run again:
+
+```bash
+docker compose exec app node node_modules/prisma/build/index.js \
+  migrate resolve --rolled-back 20260317_add_settings_suggestions
+docker compose restart app
+```
+
+If the database holds nothing you need, starting clean is simpler:
+
+```bash
+docker compose down -v && docker compose up -d
+```
+
 ## Comparison
 
 | Feature | DNA Studio | Google Pomelli | Canva AI |
@@ -154,6 +210,7 @@ dna-studio/
 │       └── auth/       # NextAuth configuration
 ├── prisma/             # Database schema and migrations
 ├── workers/            # BullMQ background workers
+├── docker/             # Container entrypoint (+ its tests)
 ├── docker-compose.yml  # One-command deployment
 └── Dockerfile
 ```

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Entrypoint for the DNA Studio app container.
+#
+# Applies pending Prisma migrations, then starts the Next.js server.
+#
+# Only *transient* failures — the database not being reachable yet — are
+# retried, and only a bounded number of times. A deterministic failure such as
+# a broken migration or a blocked migration history (P3009) exits non-zero
+# immediately with the real Prisma output, instead of being retried forever
+# behind a misleading "Database not ready" message. See issue #9.
+
+set -eu
+
+# Overridable so the retry logic can be exercised without a real database.
+PRISMA="${PRISMA_CMD:-node node_modules/prisma/build/index.js}"
+SERVER_CMD="${SERVER_CMD:-node server.js}"
+MAX_ATTEMPTS="${MIGRATE_MAX_ATTEMPTS:-10}"
+RETRY_DELAY="${MIGRATE_RETRY_DELAY:-5}"
+
+# Prisma error codes meaning "the database is not reachable *yet*":
+#   P1001 can't reach database server
+#   P1002 database server reached but timed out
+#   P1017 server has closed the connection
+# Every other code is a real failure that will not fix itself on retry.
+is_transient() {
+  printf '%s' "$1" | grep -qE 'P1001|P1002|P1017'
+}
+
+attempt=1
+while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+  if output="$($PRISMA migrate deploy 2>&1)"; then
+    printf '%s\n' "$output"
+    echo "==> Migrations applied. Starting server."
+    exec $SERVER_CMD
+  fi
+
+  if is_transient "$output"; then
+    echo "==> Database not reachable yet (attempt ${attempt}/${MAX_ATTEMPTS}), retrying in ${RETRY_DELAY}s..."
+    attempt=$((attempt + 1))
+    sleep "$RETRY_DELAY"
+    continue
+  fi
+
+  # Deterministic failure: surface it and stop.
+  printf '%s\n' "$output" >&2
+  echo "" >&2
+  echo "==> Migration failed and will not succeed on retry. Aborting." >&2
+
+  case "$output" in
+    *P3009*)
+      cat >&2 <<'HINT'
+
+A previous migration is recorded as failed, which blocks all further migrations.
+Inspect the history with:
+
+    docker compose exec app node node_modules/prisma/build/index.js migrate status
+
+If the failed migration made no changes (Postgres rolls each migration back on
+error), clear the record with:
+
+    docker compose exec app node node_modules/prisma/build/index.js migrate resolve --rolled-back <migration_name>
+
+Or, if the database holds nothing you need, start clean:
+
+    docker compose down -v && docker compose up -d
+HINT
+      ;;
+  esac
+
+  exit 1
+done
+
+echo "==> Database still unreachable after ${MAX_ATTEMPTS} attempts. Aborting." >&2
+exit 1

--- a/docker/entrypoint.test.sh
+++ b/docker/entrypoint.test.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# Tests for docker/entrypoint.sh — see issue #9.
+#
+# Drives the entrypoint with a fake `prisma` and a fake server so the retry
+# policy can be checked without a database or a container.
+#
+# Usage: sh docker/entrypoint.test.sh
+
+set -eu
+
+ENTRYPOINT="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/entrypoint.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+cat > fake-prisma.sh <<'FAKE'
+#!/bin/sh
+n=$(cat ./attempts 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > ./attempts
+case "$FAKE_MODE" in
+  ok)    echo "All migrations have been successfully applied."; exit 0 ;;
+  flaky) if [ "$n" -lt 3 ]; then
+           echo "Error: P1001 Can't reach database server at db:5432"; exit 1
+         else
+           echo "All migrations have been successfully applied."; exit 0
+         fi ;;
+  p3009) echo "Error: P3009"; echo "migrate found failed migrations in the target database"; exit 1 ;;
+  p3018) echo "Error: P3018"; echo 'ERROR: relation "User" does not exist'; exit 1 ;;
+  down)  echo "Error: P1001 Can't reach database server at db:5432"; exit 1 ;;
+esac
+FAKE
+chmod +x fake-prisma.sh
+
+printf '#!/bin/sh\necho SERVER_STARTED\n' > fake-server.sh
+chmod +x fake-server.sh
+
+failures=0
+
+# run <mode> <max_attempts> -> writes output to ./out, exit code to ./code,
+# prisma invocation count to ./attempts
+run() {
+  rm -f ./attempts
+  set +e
+  FAKE_MODE="$1" PRISMA_CMD="./fake-prisma.sh" SERVER_CMD="./fake-server.sh" \
+    MIGRATE_MAX_ATTEMPTS="$2" MIGRATE_RETRY_DELAY=0 \
+    sh "$ENTRYPOINT" > ./out 2>&1
+  echo $? > ./code
+  set -e
+}
+
+check() { # check <description> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    echo "  ok   - $1"
+  else
+    echo "  FAIL - $1 (expected '$2', got '$3')"
+    failures=$((failures + 1))
+  fi
+}
+
+contains() { # contains <description> <needle>
+  if grep -q -- "$2" ./out; then
+    echo "  ok   - $1"
+  else
+    echo "  FAIL - $1 (output did not contain '$2')"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "1. migrations succeed -> server starts"
+run ok 4
+check "exits 0"            0 "$(cat ./code)"
+check "runs prisma once"   1 "$(cat ./attempts)"
+contains "starts the server" "SERVER_STARTED"
+
+echo "2. database slow to accept connections -> retries, then starts"
+run flaky 4
+check "exits 0"            0 "$(cat ./code)"
+check "retries until ready" 3 "$(cat ./attempts)"
+contains "starts the server" "SERVER_STARTED"
+
+echo "3. blocked migration history (P3009) -> fails fast, no retry"
+run p3009 4
+check "exits non-zero"     1 "$(cat ./code)"
+check "does not retry"     1 "$(cat ./attempts)"
+contains "surfaces the Prisma error code" "P3009"
+contains "explains recovery"              "migrate resolve --rolled-back"
+contains "does not claim the db is down"  "will not succeed on retry"
+
+echo "4. broken migration (P3018) -> fails fast, no retry"
+run p3018 4
+check "exits non-zero"     1 "$(cat ./code)"
+check "does not retry"     1 "$(cat ./attempts)"
+contains "surfaces the real database error" 'relation "User" does not exist'
+
+echo "5. database never reachable -> bounded retries, then gives up"
+run down 3
+check "exits non-zero"          1 "$(cat ./code)"
+check "stops after max attempts" 3 "$(cat ./attempts)"
+contains "reports giving up" "still unreachable after 3 attempts"
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "All entrypoint tests passed."
+else
+  echo "$failures check(s) failed."
+  exit 1
+fi

--- a/prisma/migrations/20260317_add_settings_suggestions/migration.sql
+++ b/prisma/migrations/20260317_add_settings_suggestions/migration.sql
@@ -1,5 +1,0 @@
--- Add user settings (JSON for LLM/image provider preferences, API keys)
-ALTER TABLE "User" ADD COLUMN "settings" JSONB;
-
--- Add cached campaign suggestions to Brand
-ALTER TABLE "Brand" ADD COLUMN "suggestions" JSONB;

--- a/prisma/migrations/20260317b_add_settings_suggestions/migration.sql
+++ b/prisma/migrations/20260317b_add_settings_suggestions/migration.sql
@@ -1,0 +1,20 @@
+-- Adds user settings (LLM/image provider preferences and API keys) and cached
+-- campaign suggestions.
+--
+-- Naming: this directory is `20260317b_...`, not `20260317_add_...`, so that it
+-- sorts *after* `20260317_init` — the migration that creates the tables it
+-- alters. Prisma applies migrations in lexicographic order of the directory
+-- name, and "add_settings_suggestions" < "init", so the original name ran this
+-- ALTER against tables that did not exist yet. See issue #8.
+--
+-- A full timestamp prefix such as `20260317120000_` does NOT fix this: digits
+-- sort before `_` (0x31 < 0x5F), so it would still land ahead of `20260317_init`.
+--
+-- IF NOT EXISTS keeps this a no-op on databases that already applied it under
+-- the previous directory name.
+
+-- Add user settings (JSON for LLM/image provider preferences, API keys)
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "settings" JSONB;
+
+-- Add cached campaign suggestions to Brand
+ALTER TABLE "Brand" ADD COLUMN IF NOT EXISTS "suggestions" JSONB;

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+
+// Never cached — the container healthcheck needs the live state.
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return NextResponse.json({ status: "ok", database: "reachable" });
+  } catch (error) {
+    console.error("[health] database check failed:", error);
+    return NextResponse.json(
+      { status: "error", database: "unreachable" },
+      { status: 503 }
+    );
+  }
+}

--- a/src/app/campaigns/[id]/page.tsx
+++ b/src/app/campaigns/[id]/page.tsx
@@ -70,9 +70,10 @@ export default function CampaignPage() {
     if (pending.length === 0) return;
 
     autoGenStarted.current = true;
-    setAutoGenProgress({ done: 0, total: pending.length });
 
     (async () => {
+      setAutoGenProgress({ done: 0, total: pending.length });
+
       for (let i = 0; i < pending.length; i++) {
         const asset = pending[i];
         try {

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -47,14 +47,6 @@ export function Sidebar() {
       });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Sync active brand with URL
-  useEffect(() => {
-    const match = pathname.match(/^\/brands\/([^/]+)/);
-    if (match) {
-      setActiveBrandId(match[1]);
-    }
-  }, [pathname]);
-
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
@@ -64,6 +56,14 @@ export function Sidebar() {
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
+
+  // Keep the active brand in step with the URL. Adjusting state during render
+  // rather than in an effect avoids a cascading re-render, and keeps the last
+  // visited brand selected after navigating away from /brands/[id].
+  const brandIdFromUrl = pathname.match(/^\/brands\/([^/]+)/)?.[1] ?? null;
+  if (brandIdFromUrl && brandIdFromUrl !== activeBrandId) {
+    setActiveBrandId(brandIdFromUrl);
+  }
 
   const activeBrand = brands.find((b) => b.id === activeBrandId);
 


### PR DESCRIPTION
Fixes #8 and #9. Together they mean `docker compose up -d` has not produced a working install since March.

## #8 — migrations never applied on a fresh database

Prisma applies migrations in **lexicographic order of the directory name**. Two shared the `20260317` prefix:

| Order | Directory | Contents |
|---|---|---|
| 1 | `20260317_add_settings_suggestions` | `ALTER TABLE "User" ADD COLUMN "settings"` |
| 2 | `20260317_init` | `CREATE TABLE "User" (...)` |

`"a" < "i"`, so the `ALTER` ran first and failed with `relation "User" does not exist`. Prisma recorded the failure, and every later `migrate deploy` aborted with `P3009`. Reproduced against PostgreSQL 16 — the database ends up holding nothing but `_prisma_migrations`.

**Fix:** renamed to `20260317b_add_settings_suggestions` so it sorts after `20260317_init`. A full timestamp (`20260317120000_`) would *not* work — digits sort before `_` (`0x31` < `0x5F`). `20260317_init` is untouched, since renaming it would break databases that already applied it.

Databases that already applied the migration under the old name will apply it again under the new one, so the SQL is now idempotent (`ADD COLUMN IF NOT EXISTS`).

Verified both ways:
- fresh database → all 5 migrations apply in order, no drift against `schema.prisma`
- database with the pre-fix history → re-applies as a no-op, columns intact, no drift

## #9 — the entrypoint hid it

The retry loop reported every failure as `Database not ready, retrying in 5s...` and never gave up, so the real error scrolled past and `docker compose ps` said `Up`.

Now in `docker/entrypoint.sh`:
- retries only on Prisma connection errors (`P1001`, `P1002`, `P1017`)
- bounded — `MIGRATE_MAX_ATTEMPTS` (10), `MIGRATE_RETRY_DELAY` (5s)
- anything else prints the real Prisma output and exits non-zero
- `P3009` gets recovery instructions rather than a misleading message

Adds `/api/health` and a container `HEALTHCHECK`, so the app reports healthy only once it is serving requests *and* can reach the database.

Verified in a real container:

```
==> Migration failed and will not succeed on retry. Aborting.
Error: P3009 ... The `20260320_deliberately_broken` migration ... failed
```
```
dnae2e-app-1   Restarting (1)     # not a false "Up"
```

The documented `migrate resolve --rolled-back` recovery was tested too — the app comes back healthy afterwards.

## CI

Nothing ran on pull requests, which is why this shipped and stayed broken. Four jobs now:

| Job | What it catches |
|---|---|
| `migrations` | applies every migration to an empty database, asserts nothing pending and no drift — the regression test for #8 |
| `entrypoint` | `docker/entrypoint.test.sh`, 5 scenarios — the regression test for #9 |
| `build` | lint, typecheck, `next build` |
| `compose` | `docker compose up -d --build`, waits for healthy — a fresh install really comes up |

Also fixes the two `react-hooks/set-state-in-effect` errors that the eslint bump in #7 surfaced, so the lint gate starts green.

## Docs

`CONTRIBUTING.md` previously told contributors to name migrations `YYYYMMDD_description` — the exact thing that caused #8. It now explains the ordering rule and the traps. `README.md` gains a Troubleshooting section covering the health endpoint, restart loops, and `P3009` recovery for anyone whose install broke earlier.

## Test plan

- [x] `prisma migrate deploy` on an empty PostgreSQL 16 database
- [x] `prisma migrate deploy` on a database with the pre-fix migration history
- [x] no drift between migrations and `schema.prisma` in both cases
- [x] `sh docker/entrypoint.test.sh` — all 17 checks
- [x] `docker compose up -d --build` from an empty volume → healthy, `/api/health` 200, homepage 200
- [x] poisoned migration history → container aborts with the real error, does not report `Up`
- [x] documented `migrate resolve --rolled-back` recovery restores a healthy app
- [x] `npm run lint` (0 errors), `npx tsc --noEmit`, `npm run build`
