### PR TITLE
test: Vitest suite for the library and API routes (+ two access-control fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,20 @@ jobs:
       # bounded number of times; deterministic ones abort with the real error.
       - run: sh docker/entrypoint.test.sh
 
+  test:
+    name: Unit and API tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      # Coverage thresholds are enforced in vitest.config.mts and scoped to
+      # src/lib and src/app/api — the code that holds the logic.
+      - run: npm run test:coverage
+
   build:
     name: Lint, typecheck, build
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,14 @@ src/
    npm run lint
    ```
 
-5. **Build successfully**:
+5. **Run the tests**:
+   ```bash
+   npm test              # once
+   npm run test:watch    # while developing
+   npm run test:coverage # with the coverage gate
+   ```
+
+6. **Build successfully**:
    ```bash
    npm run build
    ```
@@ -87,9 +94,9 @@ src/
    sh docker/entrypoint.test.sh
    ```
 
-6. **Commit with clear messages** — describe what and why, not how
+7. **Commit with clear messages** — describe what and why, not how
 
-7. **Open a PR** against `main`
+8. **Open a PR** against `main`
 
 ## Adding a New LLM Provider
 
@@ -104,6 +111,36 @@ src/
 2. Add the provider type to `src/lib/image/client.ts`
 3. Add env vars to `.env.example` and `docker-compose.yml`
 4. Update `src/lib/settings/resolve.ts`
+
+## Testing
+
+Tests live in `tests/`, mirroring `src/`, and run on [Vitest](https://vitest.dev).
+
+```bash
+npm test                                  # whole suite
+npm test -- tests/lib/settings            # one directory
+npm test -- -t "masks stored API keys"    # one test by name
+```
+
+What is covered, and what is not:
+
+- **`src/lib`** — pure logic, provider clients, and every AI/social provider, with
+  the SDK or `fetch` mocked. No network, no database.
+- **`src/app/api`** — route handlers called directly, with `@/lib/db` and
+  `@/lib/auth/session` mocked. Every route has a signed-out case, and every route
+  that touches a record asserts it is scoped to the signed-in user.
+- **Not covered yet** — React components and pages. The coverage gate in
+  `vitest.config.mts` is scoped to `src/lib` and `src/app/api` for that reason,
+  at 80% of lines, statements, branches, and functions.
+
+Two things to know before writing tests here:
+
+- `beforeEach(() => someMock.mockResolvedValue(x))` is a trap. The arrow returns
+  the mock, and Vitest treats a returned function as a teardown callback, so it
+  calls the mock again after the test. Use a block body.
+- Provider clients (`src/lib/{llm,image,video}/client.ts`) memoise at module
+  scope. Call `vi.resetModules()` and re-import between tests, as the existing
+  tests do, or you will inherit the previous test's provider.
 
 ## Database Changes
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ docker compose down -v && docker compose up -d
 - **Web Scraping**: Playwright (headless Chromium)
 - **AI**: Provider-agnostic — text (OpenAI, Anthropic, Gemini, Ollama), image (OpenAI, Gemini, Stability, Replicate), video (Veo, HeyGen, D-ID)
 - **Auth**: NextAuth.js (credentials + Google OAuth)
+- **Testing**: Vitest
 - **Deployment**: Docker Compose
 
 ## Project Structure
@@ -240,10 +241,11 @@ dna-studio/
 - [x] UGC video generation with creator avatars (Veo, HeyGen, D-ID)
 - [x] Health endpoint (`/api/health`) and container healthcheck
 - [x] CI on every pull request — migrations, entrypoint, build, and a full `docker compose` boot
+- [x] Test suite — 483 tests over the library and API routes, with a coverage gate in CI
 
 ### Up Next
 
-- [ ] Test suite for the application code (providers, API routes, campaign generation)
+- [ ] Component and page tests (the suite covers `src/lib` and `src/app/api` today)
 
 - [ ] A/B testing for campaign variants
 - [ ] Analytics dashboard (post performance tracking)

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,12 +35,14 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitest/coverage-v8": "^4.1.11",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "prisma": "^6.19.3",
         "tailwindcss": "^4",
         "tsx": "^4.22.4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -200,19 +202,21 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -240,12 +244,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -295,16 +300,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1826,6 +1842,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -1918,6 +1944,268 @@
       "dependencies": {
         "@prisma/debug": "6.19.3"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -2280,6 +2568,24 @@
       "dependencies": {
         "bcryptjs": "*"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2856,6 +3162,162 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.11",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3075,11 +3537,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -3372,6 +3863,16 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3882,6 +4383,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4402,6 +4910,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4409,6 +4927,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -4910,6 +5438,13 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5357,6 +5892,45 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -5854,6 +6428,49 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -6782,6 +7399,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
@@ -7332,6 +7963,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.146.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7654,6 +8319,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7668,10 +8340,24 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7888,6 +8574,13 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
@@ -7899,13 +8592,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7942,6 +8636,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8267,6 +8971,505 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8365,6 +9568,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
@@ -41,11 +44,13 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^4.1.11",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "prisma": "^6.19.3",
     "tailwindcss": "^4",
     "tsx": "^4.22.4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.11"
   }
 }

--- a/src/app/api/brands/[id]/route.ts
+++ b/src/app/api/brands/[id]/route.ts
@@ -1,6 +1,23 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { requireSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/db";
+
+// Fields a user is allowed to edit. Deliberately excludes `id` and `userId`:
+// passing the request body straight to prisma.update let a caller reassign
+// their brand to another account by sending {"userId": "..."}.
+const updateBrandSchema = z
+  .object({
+    name: z.string().min(1),
+    url: z.string().url(),
+    logoUrl: z.string().nullable(),
+    colors: z.array(z.string()),
+    fonts: z.array(z.string()),
+    tone: z.string(),
+    industry: z.string(),
+    audience: z.string(),
+  })
+  .partial();
 
 export async function GET(
   _request: Request,
@@ -43,7 +60,7 @@ export async function PATCH(
   try {
     const session = await requireSession();
     const { id } = await params;
-    const body = await request.json();
+    const data = updateBrandSchema.parse(await request.json());
 
     const brand = await prisma.brand.findFirst({
       where: { id, userId: session.user.id },
@@ -55,13 +72,19 @@ export async function PATCH(
 
     const updated = await prisma.brand.update({
       where: { id },
-      data: body,
+      data,
     });
 
     return NextResponse.json(updated);
   } catch (error) {
     if (error instanceof Error && error.message === "Unauthorized") {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid request body", issues: error.issues },
+        { status: 400 }
+      );
     }
     return NextResponse.json(
       { error: "Internal server error" },

--- a/src/app/api/images/generate/route.ts
+++ b/src/app/api/images/generate/route.ts
@@ -13,7 +13,7 @@ const schema = z.object({
 
 export async function POST(request: Request) {
   try {
-    await requireSession();
+    const session = await requireSession();
     const body = await request.json();
     const { prompt, size, assetId } = schema.parse(body);
 
@@ -21,10 +21,16 @@ export async function POST(request: Request) {
     const { url: imageUrl } = await provider.generate(prompt, { size: size as ImageSize });
 
     if (assetId) {
-      await prisma.asset.update({
-        where: { id: assetId },
+      // Scoped through the campaign relation: updating by id alone let any
+      // signed-in caller overwrite an asset belonging to another account.
+      const { count } = await prisma.asset.updateMany({
+        where: { id: assetId, campaign: { userId: session.user.id } },
         data: { imageUrl },
       });
+
+      if (count === 0) {
+        return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+      }
     }
 
     return NextResponse.json({ url: imageUrl });

--- a/tests/api/auth-register.test.ts
+++ b/tests/api/auth-register.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: { user: { findUnique: vi.fn(), create: vi.fn() } },
+}));
+vi.mock("bcryptjs", () => ({
+  default: { hash: vi.fn(async (value: string) => `hashed:${value}`) },
+}));
+
+import { prisma } from "@/lib/db";
+import bcrypt from "bcryptjs";
+import { POST as register } from "@/app/api/auth/register/route";
+
+const user = vi.mocked(prisma.user);
+const hash = vi.mocked(bcrypt.hash);
+
+const post = (body: unknown) =>
+  new Request("http://localhost/api/auth/register", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+const valid = { name: "Ada", email: "ada@example.com", password: "correct horse battery" };
+
+beforeEach(() => {
+  user.findUnique.mockResolvedValue(null as never);
+  user.create.mockResolvedValue({ id: "user_1", name: "Ada", email: "ada@example.com" } as never);
+});
+
+describe("POST /api/auth/register", () => {
+  it("creates the account and returns it without the password", async () => {
+    const response = await register(post(valid));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "user_1",
+      name: "Ada",
+      email: "ada@example.com",
+    });
+  });
+
+  it("never stores the password in the clear", async () => {
+    await register(post(valid));
+
+    const data = (user.create.mock.calls[0][0] as { data: { password: string } }).data;
+    expect(data.password).not.toBe(valid.password);
+    expect(data.password).toBe(`hashed:${valid.password}`);
+    expect(hash).toHaveBeenCalledWith(valid.password, 12);
+  });
+
+  it("answers 409 for an email that is already registered", async () => {
+    user.findUnique.mockResolvedValue({ id: "existing" } as never);
+
+    const response = await register(post(valid));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "Email already registered" });
+    expect(user.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a missing name", { ...valid, name: "" }],
+    ["a malformed email", { ...valid, email: "not-an-email" }],
+    ["a password under eight characters", { ...valid, password: "short" }],
+    ["a missing body", {}],
+  ])("answers 400 for %s", async (_label, body) => {
+    const response = await register(post(body));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "Invalid input" });
+    expect(user.create).not.toHaveBeenCalled();
+  });
+
+  it("answers 500 when the database fails, without leaking the error", async () => {
+    user.create.mockRejectedValue(new Error("connection refused"));
+
+    const response = await register(post(valid));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Internal server error" });
+  });
+});

--- a/tests/api/brands.test.ts
+++ b/tests/api/brands.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => {
+  const model = () => ({
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  });
+  return { prisma: { brand: model(), campaign: model(), user: model() } };
+});
+vi.mock("@/lib/auth/session", () => ({
+  requireSession: vi.fn(),
+  getSession: vi.fn(),
+}));
+
+import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/auth/session";
+import { GET as listBrands } from "@/app/api/brands/route";
+import {
+  GET as getBrand,
+  PATCH as patchBrand,
+  DELETE as deleteBrand,
+} from "@/app/api/brands/[id]/route";
+
+const brand = vi.mocked(prisma.brand);
+const session = vi.mocked(requireSession);
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+const patchRequest = (body: unknown) =>
+  new Request("http://localhost/api/brands/brand_1", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+
+const UNAUTHORIZED = new Error("Unauthorized");
+
+beforeEach(() => {
+  session.mockResolvedValue({ user: { id: "user_1", email: "a@b.c" } } as never);
+});
+
+describe("GET /api/brands", () => {
+  it("returns the signed-in user's brands, newest first", async () => {
+    brand.findMany.mockResolvedValue([{ id: "brand_1" }] as never);
+
+    const response = await listBrands();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual([{ id: "brand_1" }]);
+    expect(brand.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user_1" },
+        orderBy: { createdAt: "desc" },
+      })
+    );
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(UNAUTHORIZED);
+
+    const response = await listBrands();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(brand.findMany).not.toHaveBeenCalled();
+  });
+
+  it("answers 500 when the database fails, without leaking the error", async () => {
+    brand.findMany.mockRejectedValue(new Error("connection refused"));
+
+    const response = await listBrands();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Internal server error" });
+  });
+});
+
+describe("GET /api/brands/[id]", () => {
+  it("returns a brand the user owns", async () => {
+    brand.findFirst.mockResolvedValue({ id: "brand_1", campaigns: [] } as never);
+
+    const response = await getBrand(new Request("http://localhost"), params("brand_1"));
+
+    expect(response.status).toBe(200);
+    expect(brand.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "brand_1", userId: "user_1" } })
+    );
+  });
+
+  it("answers 404 for a brand belonging to someone else", async () => {
+    brand.findFirst.mockResolvedValue(null as never);
+
+    const response = await getBrand(new Request("http://localhost"), params("brand_1"));
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Brand not found" });
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(UNAUTHORIZED);
+    const response = await getBrand(new Request("http://localhost"), params("brand_1"));
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("PATCH /api/brands/[id]", () => {
+  beforeEach(() => {
+    brand.findFirst.mockResolvedValue({ id: "brand_1", userId: "user_1" } as never);
+    brand.update.mockResolvedValue({ id: "brand_1", name: "Renamed" } as never);
+  });
+
+  it("updates the fields a user is allowed to change", async () => {
+    const response = await patchBrand(
+      patchRequest({ name: "Renamed", tone: "playful" }),
+      params("brand_1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(brand.update).toHaveBeenCalledWith({
+      where: { id: "brand_1" },
+      data: { name: "Renamed", tone: "playful" },
+    });
+  });
+
+  it("ignores userId in the body so a brand cannot be reassigned", async () => {
+    const response = await patchBrand(
+      patchRequest({ name: "Renamed", userId: "someone_else" }),
+      params("brand_1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(brand.update).toHaveBeenCalledWith({
+      where: { id: "brand_1" },
+      data: { name: "Renamed" },
+    });
+  });
+
+  it("ignores an attempt to rewrite the primary key", async () => {
+    await patchBrand(patchRequest({ id: "other_brand", name: "Renamed" }), params("brand_1"));
+
+    expect(brand.update).toHaveBeenCalledWith({
+      where: { id: "brand_1" },
+      data: { name: "Renamed" },
+    });
+  });
+
+  it("answers 400 for a field of the wrong type", async () => {
+    const response = await patchBrand(patchRequest({ name: 42 }), params("brand_1"));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "Invalid request body" });
+    expect(brand.update).not.toHaveBeenCalled();
+  });
+
+  it("answers 400 for a malformed url", async () => {
+    const response = await patchBrand(patchRequest({ url: "not-a-url" }), params("brand_1"));
+    expect(response.status).toBe(400);
+  });
+
+  it("answers 404 without updating when the brand is not the user's", async () => {
+    brand.findFirst.mockResolvedValue(null as never);
+
+    const response = await patchBrand(patchRequest({ name: "Renamed" }), params("brand_1"));
+
+    expect(response.status).toBe(404);
+    expect(brand.update).not.toHaveBeenCalled();
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(UNAUTHORIZED);
+    const response = await patchBrand(patchRequest({ name: "Renamed" }), params("brand_1"));
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("DELETE /api/brands/[id]", () => {
+  it("deletes a brand the user owns", async () => {
+    brand.findFirst.mockResolvedValue({ id: "brand_1" } as never);
+    brand.delete.mockResolvedValue({} as never);
+
+    const response = await deleteBrand(new Request("http://localhost"), params("brand_1"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(brand.delete).toHaveBeenCalledWith({ where: { id: "brand_1" } });
+  });
+
+  it("answers 404 without deleting when the brand is not the user's", async () => {
+    brand.findFirst.mockResolvedValue(null as never);
+
+    const response = await deleteBrand(new Request("http://localhost"), params("brand_1"));
+
+    expect(response.status).toBe(404);
+    expect(brand.delete).not.toHaveBeenCalled();
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(UNAUTHORIZED);
+    const response = await deleteBrand(new Request("http://localhost"), params("brand_1"));
+    expect(response.status).toBe(401);
+  });
+});

--- a/tests/api/campaign-publish-schedule.test.ts
+++ b/tests/api/campaign-publish-schedule.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { queueAdd, queueClose, queueCtor } = vi.hoisted(() => ({
+  queueAdd: vi.fn(),
+  queueClose: vi.fn(),
+  queueCtor: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => {
+  const model = () => ({ findFirst: vi.fn(), update: vi.fn() });
+  return { prisma: { campaign: model(), asset: model(), socialConnection: model() } };
+});
+vi.mock("@/lib/auth/session", () => ({ requireSession: vi.fn(), getSession: vi.fn() }));
+vi.mock("bullmq", () => ({
+  Queue: function (name: string, options: unknown) {
+    queueCtor(name, options);
+    return { add: queueAdd, close: queueClose };
+  },
+}));
+vi.mock("@/lib/social/meta", () => ({
+  publishToFacebook: vi.fn(),
+  publishToInstagram: vi.fn(),
+}));
+vi.mock("@/lib/social/twitter", () => ({ publishToTwitter: vi.fn() }));
+vi.mock("@/lib/social/linkedin", () => ({ publishToLinkedIn: vi.fn() }));
+
+import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/auth/session";
+import { publishToFacebook, publishToInstagram } from "@/lib/social/meta";
+import { publishToTwitter } from "@/lib/social/twitter";
+import { publishToLinkedIn } from "@/lib/social/linkedin";
+import { POST as schedule } from "@/app/api/campaigns/[id]/schedule/route";
+import { POST as publish } from "@/app/api/campaigns/[id]/publish/route";
+
+const campaign = vi.mocked(prisma.campaign);
+const asset = vi.mocked(prisma.asset);
+const connection = vi.mocked(prisma.socialConnection);
+const session = vi.mocked(requireSession);
+
+const params = { params: Promise.resolve({ id: "camp_1" }) };
+const post = (body: unknown) =>
+  new Request("http://localhost/api/campaigns/camp_1", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+const makeAsset = (overrides: Record<string, unknown> = {}) => ({
+  id: "asset_1",
+  platform: "twitter",
+  caption: "Hello",
+  hashtags: ["coffee"],
+  imageUrl: null,
+  ...overrides,
+});
+
+beforeEach(() => {
+  session.mockResolvedValue({ user: { id: "user_1", email: "a@b.c" } } as never);
+  asset.update.mockResolvedValue({} as never);
+});
+
+describe("POST /api/campaigns/[id]/schedule", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-25T12:00:00.000Z"));
+    campaign.findFirst.mockResolvedValue({ id: "camp_1", assets: [makeAsset()] } as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const future = "2026-08-25T13:00:00.000Z";
+
+  it("queues a delayed job per asset and marks it scheduled", async () => {
+    const response = await schedule(post({ assetIds: ["asset_1"], scheduledAt: future }), params);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ scheduled: 1 });
+
+    expect(queueAdd).toHaveBeenCalledWith(
+      "publish",
+      { assetId: "asset_1", campaignId: "camp_1", userId: "user_1" },
+      { delay: 3_600_000, removeOnComplete: true }
+    );
+    expect(asset.update).toHaveBeenCalledWith({
+      where: { id: "asset_1" },
+      data: { status: "scheduled", scheduledAt: new Date(future) },
+    });
+  });
+
+  it("closes the queue connection when it is done", async () => {
+    await schedule(post({ assetIds: ["asset_1"], scheduledAt: future }), params);
+    expect(queueClose).toHaveBeenCalled();
+  });
+
+  it("connects to the redis instance named in REDIS_URL", async () => {
+    vi.stubEnv("REDIS_URL", "redis://redis-host:6380");
+    await schedule(post({ assetIds: ["asset_1"], scheduledAt: future }), params);
+
+    expect(queueCtor).toHaveBeenCalledWith(
+      "social-publish",
+      expect.objectContaining({ connection: { host: "redis-host", port: 6380 } })
+    );
+  });
+
+  it("refuses a time in the past", async () => {
+    const response = await schedule(
+      post({ assetIds: ["asset_1"], scheduledAt: "2026-08-25T11:00:00.000Z" }),
+      params
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Scheduled time must be in the future",
+    });
+    expect(queueAdd).not.toHaveBeenCalled();
+  });
+
+  it("answers 400 for a malformed timestamp", async () => {
+    const response = await schedule(
+      post({ assetIds: ["asset_1"], scheduledAt: "next tuesday" }),
+      params
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("answers 404 for a campaign the user does not own", async () => {
+    campaign.findFirst.mockResolvedValue(null as never);
+    const response = await schedule(post({ assetIds: ["asset_1"], scheduledAt: future }), params);
+    expect(response.status).toBe(404);
+    expect(queueAdd).not.toHaveBeenCalled();
+  });
+
+  it("only schedules assets that belong to the campaign", async () => {
+    await schedule(post({ assetIds: ["asset_1", "not_mine"], scheduledAt: future }), params);
+
+    expect(campaign.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "camp_1", userId: "user_1" },
+        include: { assets: { where: { id: { in: ["asset_1", "not_mine"] } } } },
+      })
+    );
+    expect(queueAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await schedule(post({ assetIds: [], scheduledAt: future }), params)).status).toBe(401);
+  });
+});
+
+describe("POST /api/campaigns/[id]/publish", () => {
+  beforeEach(() => {
+    connection.findFirst.mockResolvedValue({
+      accessToken: "token",
+      refreshToken: "secret",
+      accountId: "acct_1",
+    } as never);
+    vi.mocked(publishToTwitter).mockResolvedValue({ id: "t1" } as never);
+    vi.mocked(publishToFacebook).mockResolvedValue({ id: "f1" } as never);
+    vi.mocked(publishToInstagram).mockResolvedValue({ id: "i1" } as never);
+    vi.mocked(publishToLinkedIn).mockResolvedValue({ id: "l1" } as never);
+  });
+
+  it("publishes a tweet and marks the asset published", async () => {
+    campaign.findFirst.mockResolvedValue({ id: "camp_1", assets: [makeAsset()] } as never);
+
+    const response = await publish(post({ assetIds: ["asset_1"] }), params);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      results: [{ assetId: "asset_1", status: "published", result: { id: "t1" } }],
+    });
+    expect(asset.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: "published" }) })
+    );
+  });
+
+  it("appends hashtags to the caption", async () => {
+    campaign.findFirst.mockResolvedValue({
+      id: "camp_1",
+      assets: [makeAsset({ hashtags: ["coffee", "mugs"] })],
+    } as never);
+
+    await publish(post({ assetIds: ["asset_1"] }), params);
+
+    expect(vi.mocked(publishToTwitter).mock.calls[0][0].text).toBe("Hello\n\n#coffee #mugs");
+  });
+
+  it("truncates a tweet to 280 characters", async () => {
+    campaign.findFirst.mockResolvedValue({
+      id: "camp_1",
+      assets: [makeAsset({ caption: "x".repeat(400) })],
+    } as never);
+
+    await publish(post({ assetIds: ["asset_1"] }), params);
+
+    expect(vi.mocked(publishToTwitter).mock.calls[0][0].text).toHaveLength(280);
+  });
+
+  it.each([
+    ["facebook", () => publishToFacebook],
+    ["instagram", () => publishToInstagram],
+    ["linkedin", () => publishToLinkedIn],
+  ])("routes a %s asset to its publisher", async (platform, publisher) => {
+    campaign.findFirst.mockResolvedValue({
+      id: "camp_1",
+      assets: [makeAsset({ platform, imageUrl: "https://cdn/i.png" })],
+    } as never);
+
+    await publish(post({ assetIds: ["asset_1"] }), params);
+
+    expect(publisher()).toHaveBeenCalled();
+  });
+
+  it("reports a missing connection without calling any publisher", async () => {
+    campaign.findFirst.mockResolvedValue({ id: "camp_1", assets: [makeAsset()] } as never);
+    connection.findFirst.mockResolvedValue(null as never);
+
+    const body = await (await publish(post({ assetIds: ["asset_1"] }), params)).json();
+
+    expect(body.results).toEqual([
+      { assetId: "asset_1", status: "failed", error: "No twitter account connected" },
+    ]);
+    expect(publishToTwitter).not.toHaveBeenCalled();
+    expect(asset.update).not.toHaveBeenCalled();
+  });
+
+  it("marks the asset failed and keeps going when a publisher throws", async () => {
+    campaign.findFirst.mockResolvedValue({
+      id: "camp_1",
+      assets: [makeAsset({ id: "a1" }), makeAsset({ id: "a2" })],
+    } as never);
+    vi.mocked(publishToTwitter)
+      .mockRejectedValueOnce(new Error("rate limited"))
+      .mockResolvedValueOnce({ id: "t2" } as never);
+
+    const body = await (await publish(post({ assetIds: ["a1", "a2"] }), params)).json();
+
+    expect(body.results[0]).toEqual({ assetId: "a1", status: "failed", error: "rate limited" });
+    expect(body.results[1]).toMatchObject({ assetId: "a2", status: "published" });
+    expect(asset.update).toHaveBeenCalledWith({ where: { id: "a1" }, data: { status: "failed" } });
+  });
+
+  it("looks up the connection for the signed-in user and the asset's platform", async () => {
+    campaign.findFirst.mockResolvedValue({ id: "camp_1", assets: [makeAsset()] } as never);
+
+    await publish(post({ assetIds: ["asset_1"] }), params);
+
+    expect(connection.findFirst).toHaveBeenCalledWith({
+      where: { userId: "user_1", platform: "twitter" },
+    });
+  });
+
+  it("answers 404 for a campaign the user does not own", async () => {
+    campaign.findFirst.mockResolvedValue(null as never);
+    expect((await publish(post({ assetIds: ["asset_1"] }), params)).status).toBe(404);
+  });
+
+  it("answers 400 when assetIds is not an array", async () => {
+    expect((await publish(post({ assetIds: "asset_1" }), params)).status).toBe(400);
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await publish(post({ assetIds: [] }), params)).status).toBe(401);
+  });
+});

--- a/tests/api/campaigns.test.ts
+++ b/tests/api/campaigns.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => {
+  const model = () => ({
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  });
+  return { prisma: { campaign: model(), brand: model() } };
+});
+vi.mock("@/lib/auth/session", () => ({ requireSession: vi.fn(), getSession: vi.fn() }));
+vi.mock("@/lib/llm/client", () => ({ generateJSON: vi.fn() }));
+
+import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/auth/session";
+import { generateJSON } from "@/lib/llm/client";
+import { GET as listCampaigns } from "@/app/api/campaigns/route";
+import {
+  GET as getSuggestions,
+  PATCH as patchSuggestion,
+} from "@/app/api/campaigns/suggestions/route";
+import { makeBrandDNA } from "../fixtures/brand-dna";
+
+const campaign = vi.mocked(prisma.campaign);
+const brand = vi.mocked(prisma.brand);
+const session = vi.mocked(requireSession);
+const llm = vi.mocked(generateJSON);
+
+const get = (query = "") => new Request(`http://localhost/api/campaigns/suggestions${query}`);
+const patch = (query: string, body: unknown) =>
+  new Request(`http://localhost/api/campaigns/suggestions${query}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+
+const SUGGESTIONS = [
+  { title: "Morning ritual", description: "d", imagePrompt: "p" },
+  { title: "Bean to cup", description: "d", imagePrompt: "p" },
+];
+
+beforeEach(() => {
+  session.mockResolvedValue({ user: { id: "user_1", email: "a@b.c" } } as never);
+});
+
+describe("GET /api/campaigns", () => {
+  it("lists the user's campaigns newest first", async () => {
+    campaign.findMany.mockResolvedValue([{ id: "c1" }] as never);
+
+    expect((await listCampaigns()).status).toBe(200);
+    expect(campaign.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: "user_1" }, orderBy: { createdAt: "desc" } })
+    );
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await listCampaigns()).status).toBe(401);
+  });
+
+  it("answers 500 when the database fails", async () => {
+    campaign.findMany.mockRejectedValue(new Error("db down"));
+    expect((await listCampaigns()).status).toBe(500);
+  });
+});
+
+describe("GET /api/campaigns/suggestions", () => {
+  beforeEach(() => {
+    brand.findFirst.mockResolvedValue({
+      id: "brand_1",
+      dna: makeBrandDNA(),
+      suggestions: null,
+    } as never);
+    brand.update.mockResolvedValue({} as never);
+    llm.mockResolvedValue({ suggestions: SUGGESTIONS } as never);
+  });
+
+  it("requires a brandId", async () => {
+    const response = await getSuggestions(get(""));
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "brandId is required" });
+  });
+
+  it("answers 404 for a brand the user does not own", async () => {
+    brand.findFirst.mockResolvedValue(null as never);
+    expect((await getSuggestions(get("?brandId=brand_1"))).status).toBe(404);
+  });
+
+  it("scopes the brand lookup to the signed-in user", async () => {
+    await getSuggestions(get("?brandId=brand_1"));
+    expect(brand.findFirst).toHaveBeenCalledWith({
+      where: { id: "brand_1", userId: "user_1" },
+    });
+  });
+
+  it("generates and caches suggestions when none are stored", async () => {
+    const response = await getSuggestions(get("?brandId=brand_1"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(SUGGESTIONS);
+    expect(brand.update).toHaveBeenCalledWith({
+      where: { id: "brand_1" },
+      data: { suggestions: SUGGESTIONS },
+    });
+  });
+
+  it("serves cached suggestions without calling the model", async () => {
+    brand.findFirst.mockResolvedValue({
+      id: "brand_1",
+      dna: makeBrandDNA(),
+      suggestions: SUGGESTIONS,
+    } as never);
+
+    await expect((await getSuggestions(get("?brandId=brand_1"))).json()).resolves.toEqual(
+      SUGGESTIONS
+    );
+    expect(llm).not.toHaveBeenCalled();
+  });
+
+  it("regenerates when refresh=true even if a cache exists", async () => {
+    brand.findFirst.mockResolvedValue({
+      id: "brand_1",
+      dna: makeBrandDNA(),
+      suggestions: SUGGESTIONS,
+    } as never);
+
+    await getSuggestions(get("?brandId=brand_1&refresh=true"));
+
+    expect(llm).toHaveBeenCalled();
+  });
+
+  it("ignores an empty cached array and regenerates", async () => {
+    brand.findFirst.mockResolvedValue({
+      id: "brand_1",
+      dna: makeBrandDNA(),
+      suggestions: [],
+    } as never);
+
+    await getSuggestions(get("?brandId=brand_1"));
+
+    expect(llm).toHaveBeenCalled();
+  });
+
+  it("prompts the model with the brand's own DNA", async () => {
+    await getSuggestions(get("?brandId=brand_1"));
+
+    const messages = llm.mock.calls[0][0] as { role: string; content: string }[];
+    const userPrompt = messages.find((m) => m.role === "user")!.content;
+    expect(userPrompt).toContain("Acme Coffee");
+    expect(userPrompt).toContain("Food & Beverage");
+    expect(userPrompt).toContain("#6F4E37");
+  });
+
+  it("answers 500 when generation fails", async () => {
+    llm.mockRejectedValue(new Error("model unavailable"));
+
+    const response = await getSuggestions(get("?brandId=brand_1"));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to generate suggestions" });
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await getSuggestions(get("?brandId=brand_1"))).status).toBe(401);
+  });
+});
+
+describe("PATCH /api/campaigns/suggestions", () => {
+  beforeEach(() => {
+    brand.findFirst.mockResolvedValue({ id: "brand_1", suggestions: [...SUGGESTIONS] } as never);
+    brand.update.mockResolvedValue({} as never);
+  });
+
+  it("attaches a generated image to one cached suggestion", async () => {
+    const response = await patchSuggestion(
+      patch("?brandId=brand_1", { index: 1, imageUrl: "https://cdn/img.png" }),
+      );
+
+    expect(response.status).toBe(200);
+    const saved = (
+      brand.update.mock.calls[0][0] as unknown as {
+        data: { suggestions: { imageUrl?: string }[] };
+      }
+    ).data.suggestions;
+    expect(saved[1].imageUrl).toBe("https://cdn/img.png");
+    expect(saved[0].imageUrl).toBeUndefined();
+  });
+
+  it.each([
+    ["no brandId", "", { index: 0, imageUrl: "https://cdn/i.png" }],
+    ["no index", "?brandId=brand_1", { imageUrl: "https://cdn/i.png" }],
+    ["no imageUrl", "?brandId=brand_1", { index: 0 }],
+  ])("answers 400 with %s", async (_label, query, body) => {
+    const response = await patchSuggestion(patch(query, body));
+    expect(response.status).toBe(400);
+    expect(brand.update).not.toHaveBeenCalled();
+  });
+
+  it("answers 404 when the brand has no cached suggestions", async () => {
+    brand.findFirst.mockResolvedValue({ id: "brand_1", suggestions: null } as never);
+
+    const response = await patchSuggestion(
+      patch("?brandId=brand_1", { index: 0, imageUrl: "https://cdn/i.png" })
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("ignores an out-of-range index without writing", async () => {
+    const response = await patchSuggestion(
+      patch("?brandId=brand_1", { index: 99, imageUrl: "https://cdn/i.png" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(brand.update).not.toHaveBeenCalled();
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    const response = await patchSuggestion(
+      patch("?brandId=brand_1", { index: 0, imageUrl: "https://cdn/i.png" })
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/tests/api/health.test.ts
+++ b/tests/api/health.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({ prisma: { $queryRaw: vi.fn() } }));
+
+import { prisma } from "@/lib/db";
+import { GET as health } from "@/app/api/health/route";
+
+const queryRaw = vi.mocked(prisma.$queryRaw);
+
+beforeEach(() => {
+  queryRaw.mockResolvedValue([{ "?column?": 1 }] as never);
+});
+
+describe("GET /api/health", () => {
+  it("reports ok when the database answers", async () => {
+    const response = await health();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "ok", database: "reachable" });
+  });
+
+  it("actually queries the database rather than answering blind", async () => {
+    await health();
+    expect(queryRaw).toHaveBeenCalled();
+  });
+
+  it("reports 503 when the database is unreachable, so the container is marked unhealthy", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    queryRaw.mockRejectedValue(new Error("connection refused"));
+
+    const response = await health();
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      status: "error",
+      database: "unreachable",
+    });
+  });
+
+  it("does not leak the database error to the caller", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    queryRaw.mockRejectedValue(new Error("password authentication failed for user"));
+
+    const body = await (await health()).json();
+
+    expect(JSON.stringify(body)).not.toContain("password");
+  });
+});

--- a/tests/api/images-and-generation.test.ts
+++ b/tests/api/images-and-generation.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => {
+  const model = () => ({
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+  });
+  return { prisma: { asset: model(), campaign: model() } };
+});
+vi.mock("@/lib/auth/session", () => ({ requireSession: vi.fn(), getSession: vi.fn() }));
+vi.mock("@/lib/image/client", () => ({ getImageProvider: vi.fn() }));
+vi.mock("@/lib/video/client", () => ({ getVideoProvider: vi.fn() }));
+vi.mock("@/lib/llm/client", () => ({ generateText: vi.fn() }));
+
+import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/auth/session";
+import { getImageProvider } from "@/lib/image/client";
+import { getVideoProvider } from "@/lib/video/client";
+import { generateText } from "@/lib/llm/client";
+import { POST as generateImage } from "@/app/api/images/generate/route";
+import { POST as ugcGenerate } from "@/app/api/ugc/generate/route";
+import { GET as getCampaign } from "@/app/api/campaigns/[id]/route";
+
+const asset = vi.mocked(prisma.asset);
+const campaign = vi.mocked(prisma.campaign);
+const session = vi.mocked(requireSession);
+const imageProvider = vi.mocked(getImageProvider);
+const videoProvider = vi.mocked(getVideoProvider);
+const llmText = vi.mocked(generateText);
+
+const post = (url: string, body: unknown) =>
+  new Request(`http://localhost${url}`, { method: "POST", body: JSON.stringify(body) });
+
+beforeEach(() => {
+  session.mockResolvedValue({ user: { id: "user_1", email: "a@b.c" } } as never);
+});
+
+describe("POST /api/images/generate", () => {
+  const generate = vi.fn();
+
+  beforeEach(() => {
+    generate.mockResolvedValue({ url: "https://cdn/out.png" });
+    imageProvider.mockResolvedValue({ generate } as never);
+    asset.updateMany.mockResolvedValue({ count: 1 } as never);
+  });
+
+  it("returns the generated image URL", async () => {
+    const response = await generateImage(post("/api/images/generate", { prompt: "a mug" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ url: "https://cdn/out.png" });
+    expect(generate).toHaveBeenCalledWith("a mug", { size: "1024x1024" });
+  });
+
+  it("passes a requested size through", async () => {
+    await generateImage(post("/api/images/generate", { prompt: "a mug", size: "1792x1024" }));
+    expect(generate).toHaveBeenCalledWith("a mug", { size: "1792x1024" });
+  });
+
+  it("does not touch the database when no assetId is given", async () => {
+    await generateImage(post("/api/images/generate", { prompt: "a mug" }));
+    expect(asset.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("only updates an asset that belongs to the caller", async () => {
+    await generateImage(post("/api/images/generate", { prompt: "a mug", assetId: "asset_1" }));
+
+    expect(asset.updateMany).toHaveBeenCalledWith({
+      where: { id: "asset_1", campaign: { userId: "user_1" } },
+      data: { imageUrl: "https://cdn/out.png" },
+    });
+  });
+
+  it("answers 404 rather than writing to someone else's asset", async () => {
+    asset.updateMany.mockResolvedValue({ count: 0 } as never);
+
+    const response = await generateImage(
+      post("/api/images/generate", { prompt: "a mug", assetId: "someone_elses_asset" })
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Asset not found" });
+  });
+
+  it.each([
+    ["an empty prompt", { prompt: "" }],
+    ["a missing prompt", {}],
+    ["an unsupported size", { prompt: "a mug", size: "64x64" }],
+    ["an over-long prompt", { prompt: "x".repeat(4001) }],
+  ])("answers 400 for %s", async (_label, body) => {
+    const response = await generateImage(post("/api/images/generate", body));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "Invalid input" });
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await generateImage(post("/api/images/generate", { prompt: "a mug" }))).status).toBe(401);
+  });
+
+  it("answers 500 when the provider fails", async () => {
+    generate.mockRejectedValue(new Error("quota exceeded"));
+    const response = await generateImage(post("/api/images/generate", { prompt: "a mug" }));
+    expect(response.status).toBe(500);
+  });
+});
+
+describe("POST /api/ugc/generate", () => {
+  const providerGenerate = vi.fn();
+  const providerStatus = vi.fn();
+
+  beforeEach(() => {
+    llmText.mockResolvedValue("  Hey! This mug changed my mornings.  ");
+    providerGenerate.mockResolvedValue({ videoId: "v_1", status: "queued" });
+    providerStatus.mockResolvedValue({ videoId: "v_1", status: "completed" });
+    videoProvider.mockResolvedValue({
+      generate: providerGenerate,
+      getStatus: providerStatus,
+    } as never);
+  });
+
+  describe("action: script", () => {
+    it("returns a trimmed generated script", async () => {
+      const response = await ugcGenerate(
+        post("/api/ugc/generate", { action: "script", productDescription: "A mug", avatarName: "Mia" })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        script: "Hey! This mug changed my mornings.",
+      });
+    });
+
+    it("puts the product and creator into the prompt", async () => {
+      await ugcGenerate(
+        post("/api/ugc/generate", { action: "script", productDescription: "A mug", avatarName: "Mia" })
+      );
+
+      const messages = llmText.mock.calls[0][0] as { role: string; content: string }[];
+      const userPrompt = messages.find((m) => m.role === "user")!.content;
+      expect(userPrompt).toContain("A mug");
+      expect(userPrompt).toContain("Mia");
+    });
+
+    it("falls back to a generic creator name", async () => {
+      await ugcGenerate(post("/api/ugc/generate", { action: "script", productDescription: "A mug" }));
+
+      const messages = llmText.mock.calls[0][0] as { role: string; content: string }[];
+      expect(messages.find((m) => m.role === "user")!.content).toContain("the creator");
+    });
+  });
+
+  describe("action: video", () => {
+    it("asks the provider to generate and returns the job", async () => {
+      const response = await ugcGenerate(
+        post("/api/ugc/generate", {
+          action: "video",
+          script: "Hello",
+          avatarId: "av_1",
+          aspectRatio: "16:9",
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ videoId: "v_1", status: "queued" });
+      expect(providerGenerate).toHaveBeenCalledWith({
+        script: "Hello",
+        avatarId: "av_1",
+        productImageUrl: undefined,
+        aspectRatio: "16:9",
+      });
+    });
+
+    it("defaults to a vertical aspect ratio", async () => {
+      await ugcGenerate(post("/api/ugc/generate", { action: "video", script: "s", avatarId: "a" }));
+      expect(providerGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({ aspectRatio: "9:16" })
+      );
+    });
+  });
+
+  describe("action: status", () => {
+    it("polls the provider for the given video", async () => {
+      const response = await ugcGenerate(
+        post("/api/ugc/generate", { action: "status", videoId: "v_1" })
+      );
+
+      expect(response.status).toBe(200);
+      expect(providerStatus).toHaveBeenCalledWith("v_1");
+    });
+  });
+
+  it("answers 400 for an unrecognised action", async () => {
+    const response = await ugcGenerate(post("/api/ugc/generate", { action: "teleport" }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid action" });
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await ugcGenerate(post("/api/ugc/generate", { action: "script" }))).status).toBe(401);
+  });
+
+  it("answers 500 when the provider fails", async () => {
+    videoProvider.mockRejectedValue(new Error("no api key"));
+    const response = await ugcGenerate(
+      post("/api/ugc/generate", { action: "video", script: "s", avatarId: "a" })
+    );
+    expect(response.status).toBe(500);
+  });
+});
+
+describe("GET /api/campaigns/[id]", () => {
+  const params = { params: Promise.resolve({ id: "camp_1" }) };
+
+  it("returns a campaign the user owns, with its assets", async () => {
+    campaign.findFirst.mockResolvedValue({ id: "camp_1", assets: [] } as never);
+
+    const response = await getCampaign(new Request("http://localhost"), params);
+
+    expect(response.status).toBe(200);
+    expect(campaign.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "camp_1", userId: "user_1" } })
+    );
+  });
+
+  it("answers 404 for someone else's campaign", async () => {
+    campaign.findFirst.mockResolvedValue(null as never);
+    expect((await getCampaign(new Request("http://localhost"), params)).status).toBe(404);
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await getCampaign(new Request("http://localhost"), params)).status).toBe(401);
+  });
+
+  it("answers 500 when the database fails", async () => {
+    campaign.findFirst.mockRejectedValue(new Error("db down"));
+    expect((await getCampaign(new Request("http://localhost"), params)).status).toBe(500);
+  });
+});

--- a/tests/api/images-describe.test.ts
+++ b/tests/api/images-describe.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { openAICreate, anthropicCreate, generateContent, getGenerativeModel, llmGenerate } =
+  vi.hoisted(() => ({
+    openAICreate: vi.fn(),
+    anthropicCreate: vi.fn(),
+    generateContent: vi.fn(),
+    getGenerativeModel: vi.fn(),
+    llmGenerate: vi.fn(),
+  }));
+
+vi.mock("@/lib/auth/session", () => ({ requireSession: vi.fn(), getSession: vi.fn() }));
+vi.mock("@/lib/settings/resolve", () => ({ resolveSettings: vi.fn() }));
+vi.mock("openai", () => ({
+  default: function () {
+    return { chat: { completions: { create: openAICreate } } };
+  },
+}));
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: function () {
+    return { messages: { create: anthropicCreate } };
+  },
+}));
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: function () {
+    return { getGenerativeModel };
+  },
+}));
+vi.mock("@/lib/llm/client", () => ({
+  getLLMProvider: vi.fn(async () => ({ generate: llmGenerate })),
+}));
+
+import { requireSession } from "@/lib/auth/session";
+import { resolveSettings } from "@/lib/settings/resolve";
+import { POST as describeImage } from "@/app/api/images/describe/route";
+
+const session = vi.mocked(requireSession);
+const settings = vi.mocked(resolveSettings);
+
+const DATA_URL = "data:image/png;base64,AAAABBBB";
+const HTTP_URL = "https://cdn/product.png";
+
+const post = (body: unknown) =>
+  new Request("http://localhost/api/images/describe", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+const withProvider = (llmProvider: string) =>
+  settings.mockResolvedValue({
+    llmProvider,
+    llmApiKey: "key",
+    llmModel: "",
+  } as never);
+
+beforeEach(() => {
+  session.mockResolvedValue({ user: { id: "user_1", email: "a@b.c" } } as never);
+  withProvider("openai");
+  openAICreate.mockResolvedValue({ choices: [{ message: { content: "A white ceramic mug" } }] });
+  anthropicCreate.mockResolvedValue({ content: [{ type: "text", text: "A white ceramic mug" }] });
+  generateContent.mockResolvedValue({ response: { text: () => "A white ceramic mug" } });
+  getGenerativeModel.mockReturnValue({ generateContent });
+  llmGenerate.mockResolvedValue({ content: "Please describe your product in text." });
+});
+
+describe("POST /api/images/describe", () => {
+  it("requires an imageUrl", async () => {
+    const response = await describeImage(post({}));
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid input" });
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await describeImage(post({ imageUrl: DATA_URL }))).status).toBe(401);
+  });
+
+  describe("openai", () => {
+    it("returns the model's description", async () => {
+      const response = await describeImage(post({ imageUrl: HTTP_URL }));
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ description: "A white ceramic mug" });
+    });
+
+    it("sends the image at high detail alongside the instruction", async () => {
+      await describeImage(post({ imageUrl: HTTP_URL }));
+
+      const content = openAICreate.mock.calls[0][0].messages[1].content;
+      expect(content[0]).toEqual({
+        type: "image_url",
+        image_url: { url: HTTP_URL, detail: "high" },
+      });
+      expect(content[1].type).toBe("text");
+    });
+
+    it("defaults the model to gpt-4o", async () => {
+      await describeImage(post({ imageUrl: HTTP_URL }));
+      expect(openAICreate.mock.calls[0][0].model).toBe("gpt-4o");
+    });
+
+    it("uses the configured model when there is one", async () => {
+      settings.mockResolvedValue({
+        llmProvider: "openai",
+        llmApiKey: "k",
+        llmModel: "gpt-4o-mini",
+      } as never);
+
+      await describeImage(post({ imageUrl: HTTP_URL }));
+      expect(openAICreate.mock.calls[0][0].model).toBe("gpt-4o-mini");
+    });
+
+    it("returns an empty description when the model says nothing", async () => {
+      openAICreate.mockResolvedValue({ choices: [{ message: { content: null } }] });
+      await expect((await describeImage(post({ imageUrl: HTTP_URL }))).json()).resolves.toEqual({
+        description: "",
+      });
+    });
+  });
+
+  describe("gemini", () => {
+    beforeEach(() => {
+      withProvider("gemini");
+    });
+
+    it("passes the decoded base64 image inline", async () => {
+      await describeImage(post({ imageUrl: DATA_URL }));
+
+      const parts = generateContent.mock.calls[0][0];
+      expect(parts[1]).toEqual({
+        inlineData: { mimeType: "image/png", data: "AAAABBBB" },
+      });
+    });
+
+    it("rejects a plain URL, which the API cannot take", async () => {
+      const response = await describeImage(post({ imageUrl: HTTP_URL }));
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: "Gemini vision requires a base64 image (data URL)",
+      });
+    });
+  });
+
+  describe("anthropic", () => {
+    beforeEach(() => {
+      withProvider("anthropic");
+    });
+
+    it("sends a base64 image block for a data URL", async () => {
+      await describeImage(post({ imageUrl: DATA_URL }));
+
+      const block = anthropicCreate.mock.calls[0][0].messages[0].content[0];
+      expect(block).toEqual({
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "AAAABBBB" },
+      });
+    });
+
+    it("sends a url image block for a plain URL", async () => {
+      await describeImage(post({ imageUrl: HTTP_URL }));
+
+      const block = anthropicCreate.mock.calls[0][0].messages[0].content[0];
+      expect(block).toEqual({ type: "image", source: { type: "url", url: HTTP_URL } });
+    });
+
+    it("returns the first text block", async () => {
+      anthropicCreate.mockResolvedValue({
+        content: [{ type: "thinking" }, { type: "text", text: "A mug" }],
+      });
+
+      await expect((await describeImage(post({ imageUrl: DATA_URL }))).json()).resolves.toEqual({
+        description: "A mug",
+      });
+    });
+
+    it("returns an empty description when there is no text block", async () => {
+      anthropicCreate.mockResolvedValue({ content: [{ type: "tool_use" }] });
+      await expect((await describeImage(post({ imageUrl: DATA_URL }))).json()).resolves.toEqual({
+        description: "",
+      });
+    });
+  });
+
+  describe("a provider without vision", () => {
+    it("falls back to asking the user to type a description", async () => {
+      withProvider("ollama");
+
+      const response = await describeImage(post({ imageUrl: DATA_URL }));
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        description: "Please describe your product in text.",
+      });
+      expect(llmGenerate).toHaveBeenCalled();
+    });
+  });
+
+  it("answers 500 with the provider's message when the call fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    openAICreate.mockRejectedValue(new Error("rate limited"));
+
+    const response = await describeImage(post({ imageUrl: HTTP_URL }));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "rate limited" });
+  });
+});

--- a/tests/api/photoshoots.test.ts
+++ b/tests/api/photoshoots.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => {
+  const model = () => ({
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  });
+  return { prisma: { photoshoot: model() } };
+});
+vi.mock("@/lib/auth/session", () => ({ requireSession: vi.fn(), getSession: vi.fn() }));
+
+import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/auth/session";
+import { GET as listShoots, POST as createShoot } from "@/app/api/photoshoots/route";
+import {
+  GET as getShoot,
+  PATCH as patchShoot,
+  DELETE as deleteShoot,
+} from "@/app/api/photoshoots/[id]/route";
+
+const photoshoot = vi.mocked(prisma.photoshoot);
+const session = vi.mocked(requireSession);
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+const request = (body: unknown) =>
+  new Request("http://localhost/api/photoshoots", { method: "POST", body: JSON.stringify(body) });
+
+beforeEach(() => {
+  session.mockResolvedValue({ user: { id: "user_1", email: "a@b.c" } } as never);
+});
+
+describe("GET /api/photoshoots", () => {
+  it("lists the user's shoots newest first", async () => {
+    photoshoot.findMany.mockResolvedValue([{ id: "ps_1" }] as never);
+
+    const response = await listShoots();
+
+    expect(response.status).toBe(200);
+    expect(photoshoot.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user_1" },
+        orderBy: { createdAt: "desc" },
+      })
+    );
+  });
+
+  it("does not return the uploaded product image in the list", async () => {
+    photoshoot.findMany.mockResolvedValue([] as never);
+    await listShoots();
+
+    const select = (photoshoot.findMany.mock.calls[0][0] as { select: Record<string, boolean> }).select;
+    expect(select).not.toHaveProperty("productImage");
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await listShoots()).status).toBe(401);
+  });
+
+  it("answers 500 when the database fails", async () => {
+    photoshoot.findMany.mockRejectedValue(new Error("db down"));
+    expect((await listShoots()).status).toBe(500);
+  });
+});
+
+describe("POST /api/photoshoots", () => {
+  beforeEach(() => {
+    photoshoot.create.mockResolvedValue({ id: "ps_1" } as never);
+  });
+
+  it("creates a shoot owned by the signed-in user and answers 201", async () => {
+    const response = await createShoot(
+      request({ productImage: "data:image/png;base64,x", productDescription: "A mug", templates: ["studio"], results: [{ url: "a" }] })
+    );
+
+    expect(response.status).toBe(201);
+    expect(photoshoot.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: "user_1",
+        productImage: "data:image/png;base64,x",
+        productDescription: "A mug",
+        templates: ["studio"],
+        status: "generating",
+      }),
+    });
+  });
+
+  it("stores nulls rather than undefined for the optional fields", async () => {
+    await createShoot(request({ templates: [], results: [] }));
+
+    expect(photoshoot.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ productImage: null, productDescription: null }),
+    });
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await createShoot(request({}))).status).toBe(401);
+    expect(photoshoot.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/photoshoots/[id]", () => {
+  it("returns a shoot the user owns", async () => {
+    photoshoot.findFirst.mockResolvedValue({ id: "ps_1" } as never);
+
+    const response = await getShoot(new Request("http://localhost"), params("ps_1"));
+
+    expect(response.status).toBe(200);
+    expect(photoshoot.findFirst).toHaveBeenCalledWith({
+      where: { id: "ps_1", userId: "user_1" },
+    });
+  });
+
+  it("answers 404 for someone else's shoot", async () => {
+    photoshoot.findFirst.mockResolvedValue(null as never);
+    expect((await getShoot(new Request("http://localhost"), params("ps_1"))).status).toBe(404);
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await getShoot(new Request("http://localhost"), params("ps_1"))).status).toBe(401);
+  });
+});
+
+describe("PATCH /api/photoshoots/[id]", () => {
+  beforeEach(() => {
+    photoshoot.findFirst.mockResolvedValue({ id: "ps_1", status: "generating" } as never);
+    photoshoot.update.mockResolvedValue({ id: "ps_1" } as never);
+  });
+
+  it("saves new results and status", async () => {
+    await patchShoot(request({ results: [{ url: "b" }], status: "complete" }), params("ps_1"));
+
+    expect(photoshoot.update).toHaveBeenCalledWith({
+      where: { id: "ps_1" },
+      data: { results: [{ url: "b" }], status: "complete" },
+    });
+  });
+
+  it("keeps the existing status when the body omits it", async () => {
+    await patchShoot(request({ results: [] }), params("ps_1"));
+
+    expect(photoshoot.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: "generating" }) })
+    );
+  });
+
+  it("answers 404 without updating someone else's shoot", async () => {
+    photoshoot.findFirst.mockResolvedValue(null as never);
+
+    const response = await patchShoot(request({ results: [] }), params("ps_1"));
+
+    expect(response.status).toBe(404);
+    expect(photoshoot.update).not.toHaveBeenCalled();
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await patchShoot(request({}), params("ps_1"))).status).toBe(401);
+  });
+});
+
+describe("DELETE /api/photoshoots/[id]", () => {
+  it("deletes a shoot the user owns", async () => {
+    photoshoot.findFirst.mockResolvedValue({ id: "ps_1" } as never);
+    photoshoot.delete.mockResolvedValue({} as never);
+
+    const response = await deleteShoot(new Request("http://localhost"), params("ps_1"));
+
+    expect(response.status).toBe(200);
+    expect(photoshoot.delete).toHaveBeenCalledWith({ where: { id: "ps_1" } });
+  });
+
+  it("answers 404 without deleting someone else's shoot", async () => {
+    photoshoot.findFirst.mockResolvedValue(null as never);
+
+    const response = await deleteShoot(new Request("http://localhost"), params("ps_1"));
+
+    expect(response.status).toBe(404);
+    expect(photoshoot.delete).not.toHaveBeenCalled();
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await deleteShoot(new Request("http://localhost"), params("ps_1"))).status).toBe(401);
+  });
+});

--- a/tests/api/settings.test.ts
+++ b/tests/api/settings.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => {
+  const model = () => ({
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    deleteMany: vi.fn(),
+  });
+  return { prisma: { user: model(), socialConnection: model() } };
+});
+vi.mock("@/lib/auth/session", () => ({ requireSession: vi.fn(), getSession: vi.fn() }));
+
+import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/auth/session";
+import { GET as getSettings, PUT as putSettings } from "@/app/api/settings/route";
+import { GET as listConnections } from "@/app/api/settings/connections/route";
+import { DELETE as deleteConnection } from "@/app/api/settings/connections/[id]/route";
+
+const user = vi.mocked(prisma.user);
+const socialConnection = vi.mocked(prisma.socialConnection);
+const session = vi.mocked(requireSession);
+
+const put = (body: unknown) =>
+  new Request("http://localhost/api/settings", { method: "PUT", body: JSON.stringify(body) });
+
+beforeEach(() => {
+  session.mockResolvedValue({ user: { id: "user_1", email: "a@b.c" } } as never);
+});
+
+describe("GET /api/settings", () => {
+  it("masks stored API keys, keeping the first and last four characters", async () => {
+    user.findUnique.mockResolvedValue({
+      settings: { llmProvider: "openai", llmApiKey: "sk-abcdefghijkl", imageApiKey: "sk-1234567890" },
+    } as never);
+
+    const body = await (await getSettings()).json();
+
+    expect(body.llmApiKey).toBe("sk-a••••ijkl");
+    expect(body.imageApiKey).toBe("sk-1••••7890");
+    expect(body.llmProvider).toBe("openai");
+  });
+
+  it("never returns a key in the clear", async () => {
+    user.findUnique.mockResolvedValue({ settings: { llmApiKey: "sk-abcdefghijkl" } } as never);
+
+    const body = await (await getSettings()).json();
+
+    expect(body.llmApiKey).not.toContain("bcdefgh");
+  });
+
+  it("masks a short key completely", async () => {
+    user.findUnique.mockResolvedValue({ settings: { llmApiKey: "short" } } as never);
+
+    expect((await (await getSettings()).json()).llmApiKey).toBe("••••");
+  });
+
+  it("returns empty strings when no keys are stored", async () => {
+    user.findUnique.mockResolvedValue({ settings: null } as never);
+
+    const body = await (await getSettings()).json();
+
+    expect(body).toEqual({ llmApiKey: "", imageApiKey: "" });
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await getSettings()).status).toBe(401);
+  });
+
+  it("answers 500 when the database fails", async () => {
+    user.findUnique.mockRejectedValue(new Error("db down"));
+    expect((await getSettings()).status).toBe(500);
+  });
+});
+
+describe("PUT /api/settings", () => {
+  beforeEach(() => {
+    user.findUnique.mockResolvedValue({
+      settings: { llmProvider: "openai", llmApiKey: "sk-original", imageApiKey: "img-original" },
+    } as never);
+    user.update.mockResolvedValue({} as never);
+  });
+
+  const savedSettings = () =>
+    (user.update.mock.calls[0][0] as { data: { settings: Record<string, unknown> } }).data.settings;
+
+  it("stores a newly supplied key", async () => {
+    await putSettings(put({ llmApiKey: "sk-brand-new" }));
+    expect(savedSettings().llmApiKey).toBe("sk-brand-new");
+  });
+
+  it("keeps the stored key when the form posts back the masked placeholder", async () => {
+    await putSettings(put({ llmApiKey: "sk-o••••inal" }));
+    expect(savedSettings().llmApiKey).toBe("sk-original");
+  });
+
+  it("keeps the stored key when the field is submitted empty", async () => {
+    await putSettings(put({ llmApiKey: "" }));
+    expect(savedSettings().llmApiKey).toBe("sk-original");
+  });
+
+  it("masks and preserves the image key on the same rules", async () => {
+    await putSettings(put({ imageApiKey: "img-••••inal" }));
+    expect(savedSettings().imageApiKey).toBe("img-original");
+  });
+
+  it("preserves settings the request did not mention", async () => {
+    await putSettings(put({ llmModel: "gpt-4o-mini" }));
+
+    const saved = savedSettings();
+    expect(saved.llmProvider).toBe("openai");
+    expect(saved.llmModel).toBe("gpt-4o-mini");
+  });
+
+  it("saves against the signed-in user only", async () => {
+    await putSettings(put({ llmProvider: "anthropic" }));
+    expect(user.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "user_1" } })
+    );
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await putSettings(put({}))).status).toBe(401);
+    expect(user.update).not.toHaveBeenCalled();
+  });
+
+  it("answers 500 when the write fails", async () => {
+    user.update.mockRejectedValue(new Error("db down"));
+    expect((await putSettings(put({}))).status).toBe(500);
+  });
+});
+
+describe("GET /api/settings/connections", () => {
+  it("returns the user's connections without secrets", async () => {
+    socialConnection.findMany.mockResolvedValue([{ id: "c1", platform: "twitter" }] as never);
+
+    const response = await listConnections();
+
+    expect(response.status).toBe(200);
+    const select = (socialConnection.findMany.mock.calls[0][0] as { select: Record<string, boolean> })
+      .select;
+    expect(select).not.toHaveProperty("accessToken");
+    expect(select).not.toHaveProperty("refreshToken");
+    expect(socialConnection.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: "user_1" } })
+    );
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await listConnections()).status).toBe(401);
+  });
+});
+
+describe("DELETE /api/settings/connections/[id]", () => {
+  it("scopes the delete to the signed-in user", async () => {
+    socialConnection.deleteMany.mockResolvedValue({ count: 1 } as never);
+
+    const response = await deleteConnection(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "conn_1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(socialConnection.deleteMany).toHaveBeenCalledWith({
+      where: { id: "conn_1", userId: "user_1" },
+    });
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    const response = await deleteConnection(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "conn_1" }),
+    });
+    expect(response.status).toBe(401);
+    expect(socialConnection.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api/streaming-routes.test.ts
+++ b/tests/api/streaming-routes.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => {
+  const model = () => ({ findFirst: vi.fn(), create: vi.fn() });
+  return { prisma: { brand: model(), campaign: model() } };
+});
+vi.mock("@/lib/auth/session", () => ({ requireSession: vi.fn(), getSession: vi.fn() }));
+vi.mock("@/lib/brand-dna/crawler", () => ({ crawlBrandDNA: vi.fn() }));
+vi.mock("@/lib/campaigns/generator", () => ({ streamCampaign: vi.fn() }));
+
+import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/auth/session";
+import { crawlBrandDNA } from "@/lib/brand-dna/crawler";
+import { streamCampaign } from "@/lib/campaigns/generator";
+import { POST as analyze } from "@/app/api/brands/analyze/route";
+import { POST as generate } from "@/app/api/campaigns/generate/route";
+import { makeBrandDNA } from "../fixtures/brand-dna";
+
+const brand = vi.mocked(prisma.brand);
+const campaign = vi.mocked(prisma.campaign);
+const session = vi.mocked(requireSession);
+const crawl = vi.mocked(crawlBrandDNA);
+const stream = vi.mocked(streamCampaign);
+
+const post = (url: string, body: unknown) =>
+  new Request(`http://localhost${url}`, { method: "POST", body: JSON.stringify(body) });
+
+/** Collect an SSE body into the list of decoded `data:` payloads. */
+async function readEvents(response: Response) {
+  const text = await response.text();
+  return text
+    .split("\n\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice("data: ".length)));
+}
+
+beforeEach(() => {
+  session.mockResolvedValue({ user: { id: "user_1", email: "a@b.c" } } as never);
+});
+
+describe("POST /api/brands/analyze", () => {
+  const dna = makeBrandDNA();
+
+  beforeEach(() => {
+    crawl.mockResolvedValue(dna as never);
+    brand.create.mockResolvedValue({ id: "brand_1", name: dna.name } as never);
+  });
+
+  it("answers 400 for a malformed URL without crawling", async () => {
+    const response = await analyze(post("/api/brands/analyze", { url: "not a url" }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "Invalid URL" });
+    expect(crawl).not.toHaveBeenCalled();
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    const response = await analyze(post("/api/brands/analyze", { url: "https://acme.coffee" }));
+    expect(response.status).toBe(401);
+  });
+
+  it("responds as an event stream", async () => {
+    const response = await analyze(post("/api/brands/analyze", { url: "https://acme.coffee" }));
+
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+    expect(response.headers.get("Cache-Control")).toBe("no-cache");
+  });
+
+  it("forwards crawl progress and finishes with the saved brand", async () => {
+    crawl.mockImplementation(async (_url, onProgress) => {
+      onProgress!({ step: "fetch", status: "running" });
+      onProgress!({ step: "fetch", status: "done" });
+      return dna as never;
+    });
+
+    const events = await readEvents(
+      await analyze(post("/api/brands/analyze", { url: "https://acme.coffee" }))
+    );
+
+    expect(events.slice(0, 2)).toEqual([
+      { type: "progress", step: "fetch", status: "running" },
+      { type: "progress", step: "fetch", status: "done" },
+    ]);
+    expect(events.at(-1)).toMatchObject({ type: "complete" });
+  });
+
+  it("saves the brand against the signed-in user, flattening the DNA", async () => {
+    await readEvents(await analyze(post("/api/brands/analyze", { url: "https://acme.coffee" })));
+
+    expect(brand.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: "user_1",
+        name: "Acme Coffee",
+        colors: ["#6F4E37", "#C0A080"],
+        fonts: ["Playfair Display", "Inter"],
+        tone: "friendly",
+        industry: "Food & Beverage",
+        audience: "Home brewers",
+      }),
+    });
+  });
+
+  it("reports a crawl failure as an error event rather than a broken stream", async () => {
+    crawl.mockRejectedValue(new Error("site unreachable"));
+
+    const events = await readEvents(
+      await analyze(post("/api/brands/analyze", { url: "https://acme.coffee" }))
+    );
+
+    expect(events).toEqual([{ type: "error", message: "site unreachable" }]);
+    expect(brand.create).not.toHaveBeenCalled();
+  });
+
+  it("reports a save failure as an error event", async () => {
+    brand.create.mockRejectedValue(new Error("db down"));
+
+    const events = await readEvents(
+      await analyze(post("/api/brands/analyze", { url: "https://acme.coffee" }))
+    );
+
+    expect(events.at(-1)).toEqual({ type: "error", message: "db down" });
+  });
+});
+
+describe("POST /api/campaigns/generate", () => {
+  const validBody = {
+    brandId: "brand_1",
+    goal: "Launch cold brew",
+    platforms: ["instagram"],
+  };
+
+  const CONCEPTS = {
+    concepts: [
+      {
+        name: "Morning ritual",
+        assets: [
+          { platform: "instagram", caption: "Hi", hashtags: ["coffee"], imagePrompt: "a mug" },
+        ],
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    brand.findFirst.mockResolvedValue({ id: "brand_1", dna: makeBrandDNA() } as never);
+    campaign.create.mockResolvedValue({ id: "camp_1", assets: [] } as never);
+    stream.mockImplementation(async function* () {
+      yield JSON.stringify(CONCEPTS);
+    } as never);
+  });
+
+  it.each([
+    ["a missing goal", { brandId: "brand_1", platforms: ["instagram"] }],
+    ["an empty goal", { ...validBody, goal: "" }],
+    ["an unsupported platform", { ...validBody, platforms: ["myspace"] }],
+  ])("answers 400 for %s", async (_label, body) => {
+    const response = await generate(post("/api/campaigns/generate", body));
+    expect(response.status).toBe(400);
+  });
+
+  it("answers 404 for a brand the user does not own", async () => {
+    brand.findFirst.mockResolvedValue(null as never);
+    const response = await generate(post("/api/campaigns/generate", validBody));
+    expect(response.status).toBe(404);
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await generate(post("/api/campaigns/generate", validBody))).status).toBe(401);
+  });
+
+  it("streams model chunks then the saved campaign", async () => {
+    stream.mockImplementation(async function* () {
+      yield '{"concepts":';
+      yield JSON.stringify(CONCEPTS.concepts) + "}";
+    } as never);
+
+    const events = await readEvents(await generate(post("/api/campaigns/generate", validBody)));
+
+    expect(events.filter((e) => e.type === "chunk")).toHaveLength(2);
+    expect(events.at(-1)).toMatchObject({ type: "complete" });
+  });
+
+  it("creates one asset per concept asset", async () => {
+    await readEvents(await generate(post("/api/campaigns/generate", validBody)));
+
+    expect(campaign.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          brandId: "brand_1",
+          userId: "user_1",
+          goal: "Launch cold brew",
+          assets: {
+            create: [
+              {
+                platform: "instagram",
+                caption: "Hi",
+                hashtags: ["coffee"],
+                imagePrompt: "a mug",
+                status: "draft",
+              },
+            ],
+          },
+        }),
+      })
+    );
+  });
+
+  it("stores a null image prompt when the model omits one", async () => {
+    stream.mockImplementation(async function* () {
+      yield JSON.stringify({
+        concepts: [
+          { name: "n", assets: [{ platform: "instagram", caption: "Hi", hashtags: [] }] },
+        ],
+      });
+    } as never);
+
+    await readEvents(await generate(post("/api/campaigns/generate", validBody)));
+
+    const created = campaign.create.mock.calls[0][0] as unknown as {
+      data: { assets: { create: { imagePrompt: string | null }[] } };
+    };
+    expect(created.data.assets.create[0].imagePrompt).toBeNull();
+  });
+
+  it("reports an error event when the model returns no JSON", async () => {
+    stream.mockImplementation(async function* () {
+      yield "I cannot help with that.";
+    } as never);
+
+    const events = await readEvents(await generate(post("/api/campaigns/generate", validBody)));
+
+    expect(events.at(-1)).toEqual({
+      type: "error",
+      message: "LLM did not return valid JSON for campaign",
+    });
+    expect(campaign.create).not.toHaveBeenCalled();
+  });
+
+  it("defaults the language to English", async () => {
+    await readEvents(await generate(post("/api/campaigns/generate", validBody)));
+    expect(stream).toHaveBeenCalledWith(expect.anything(), "Launch cold brew", ["instagram"], "English");
+  });
+
+  it("passes a requested language through", async () => {
+    await readEvents(
+      await generate(post("/api/campaigns/generate", { ...validBody, language: "Arabic" }))
+    );
+    expect(stream).toHaveBeenCalledWith(expect.anything(), "Launch cold brew", ["instagram"], "Arabic");
+  });
+});

--- a/tests/api/ugc.test.ts
+++ b/tests/api/ugc.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => {
+  const model = () => ({
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  });
+  return { prisma: { uGCVideo: model(), uGCCharacter: model() } };
+});
+vi.mock("@/lib/auth/session", () => ({ requireSession: vi.fn(), getSession: vi.fn() }));
+vi.mock("@/lib/video/client", () => ({ getVideoProvider: vi.fn() }));
+vi.mock("@/lib/settings/resolve", () => ({ resolveSettings: vi.fn() }));
+
+import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/auth/session";
+import { getVideoProvider } from "@/lib/video/client";
+import { resolveSettings } from "@/lib/settings/resolve";
+import { GET as listVideos, POST as createVideo } from "@/app/api/ugc/route";
+import { GET as getVideo, PATCH as patchVideo, DELETE as deleteVideo } from "@/app/api/ugc/[id]/route";
+import { GET as listAvatars } from "@/app/api/ugc/avatars/route";
+import { GET as download } from "@/app/api/ugc/download/route";
+
+const video = vi.mocked(prisma.uGCVideo);
+const character = vi.mocked(prisma.uGCCharacter);
+const session = vi.mocked(requireSession);
+const videoProvider = vi.mocked(getVideoProvider);
+const settings = vi.mocked(resolveSettings);
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+const body = (b: unknown) =>
+  new Request("http://localhost/api/ugc", { method: "POST", body: JSON.stringify(b) });
+
+beforeEach(() => {
+  session.mockResolvedValue({ user: { id: "user_1", email: "a@b.c" } } as never);
+});
+
+describe("GET /api/ugc", () => {
+  it("lists the user's videos newest first", async () => {
+    video.findMany.mockResolvedValue([{ id: "v1" }] as never);
+
+    expect((await listVideos()).status).toBe(200);
+    expect(video.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: "user_1" }, orderBy: { createdAt: "desc" } })
+    );
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await listVideos()).status).toBe(401);
+  });
+});
+
+describe("POST /api/ugc", () => {
+  beforeEach(() => {
+    video.create.mockResolvedValue({ id: "v1" } as never);
+  });
+
+  it("creates a video owned by the signed-in user and answers 201", async () => {
+    const response = await createVideo(
+      body({ avatarId: "av_1", script: "Try our mug", provider: "veo", aspectRatio: "16:9" })
+    );
+
+    expect(response.status).toBe(201);
+    expect(video.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: "user_1",
+        avatarId: "av_1",
+        script: "Try our mug",
+        provider: "veo",
+        aspectRatio: "16:9",
+        status: "generating",
+      }),
+    });
+  });
+
+  it("applies documented defaults", async () => {
+    await createVideo(body({ avatarId: "av_1", script: "hi" }));
+
+    expect(video.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        scriptSource: "custom",
+        provider: "heygen",
+        aspectRatio: "9:16",
+        productImage: null,
+        productDescription: null,
+      }),
+    });
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await createVideo(body({}))).status).toBe(401);
+    expect(video.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("PATCH /api/ugc/[id]", () => {
+  beforeEach(() => {
+    video.findFirst.mockResolvedValue({ id: "v1" } as never);
+    video.update.mockResolvedValue({ id: "v1" } as never);
+  });
+
+  it("writes only the fields present in the body", async () => {
+    await patchVideo(body({ status: "complete", videoUrl: "https://cdn/v.mp4" }), params("v1"));
+
+    expect(video.update).toHaveBeenCalledWith({
+      where: { id: "v1" },
+      data: { status: "complete", videoUrl: "https://cdn/v.mp4" },
+    });
+  });
+
+  it("treats a zero duration as a value worth writing", async () => {
+    await patchVideo(body({ duration: 0 }), params("v1"));
+    expect(video.update).toHaveBeenCalledWith({ where: { id: "v1" }, data: { duration: 0 } });
+  });
+
+  it("ignores fields that are not in the allowed set", async () => {
+    await patchVideo(body({ userId: "someone_else", status: "complete" }), params("v1"));
+    expect(video.update).toHaveBeenCalledWith({ where: { id: "v1" }, data: { status: "complete" } });
+  });
+
+  it("answers 404 without updating someone else's video", async () => {
+    video.findFirst.mockResolvedValue(null as never);
+    expect((await patchVideo(body({ status: "x" }), params("v1"))).status).toBe(404);
+    expect(video.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET and DELETE /api/ugc/[id]", () => {
+  it("returns a video the user owns", async () => {
+    video.findFirst.mockResolvedValue({ id: "v1" } as never);
+    expect((await getVideo(new Request("http://localhost"), params("v1"))).status).toBe(200);
+  });
+
+  it("answers 404 for someone else's video", async () => {
+    video.findFirst.mockResolvedValue(null as never);
+    expect((await getVideo(new Request("http://localhost"), params("v1"))).status).toBe(404);
+  });
+
+  it("deletes a video the user owns", async () => {
+    video.findFirst.mockResolvedValue({ id: "v1" } as never);
+    video.delete.mockResolvedValue({} as never);
+
+    expect((await deleteVideo(new Request("http://localhost"), params("v1"))).status).toBe(200);
+    expect(video.delete).toHaveBeenCalledWith({ where: { id: "v1" } });
+  });
+
+  it("answers 404 without deleting someone else's video", async () => {
+    video.findFirst.mockResolvedValue(null as never);
+    expect((await deleteVideo(new Request("http://localhost"), params("v1"))).status).toBe(404);
+    expect(video.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/ugc/avatars", () => {
+  it("returns active characters from the database, ordered", async () => {
+    character.findMany.mockResolvedValue([
+      { id: "c1", name: "Mia", description: "d", gender: "f", style: "casual", previewVideoUrl: null, thumbnailUrl: null },
+    ] as never);
+
+    const response = await listAvatars();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual([
+      { id: "c1", name: "Mia", description: "d", gender: "f", style: "casual", previewVideoUrl: null, thumbnailUrl: null },
+    ]);
+    expect(character.findMany).toHaveBeenCalledWith({
+      where: { active: true },
+      orderBy: { sortOrder: "asc" },
+    });
+  });
+
+  it("falls back to the video provider when no characters are seeded", async () => {
+    character.findMany.mockResolvedValue([] as never);
+    videoProvider.mockResolvedValue({
+      listAvatars: vi.fn().mockResolvedValue([{ id: "heygen_1" }]),
+    } as never);
+
+    await expect((await listAvatars()).json()).resolves.toEqual([{ id: "heygen_1" }]);
+  });
+
+  it("returns an empty list when the provider is unreachable", async () => {
+    character.findMany.mockResolvedValue([] as never);
+    videoProvider.mockRejectedValue(new Error("no api key"));
+
+    const response = await listAvatars();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual([]);
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await listAvatars()).status).toBe(401);
+  });
+});
+
+describe("GET /api/ugc/download", () => {
+  const get = (query: string) => new Request(`http://localhost/api/ugc/download${query}`);
+
+  beforeEach(() => {
+    settings.mockResolvedValue({ videoApiKey: "goog-key" } as never);
+  });
+
+  it("requires a fileId", async () => {
+    const response = await download(get(""));
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Missing fileId" });
+  });
+
+  it.each([
+    "../../../etc/passwd",
+    "abc/../secret",
+    "file id",
+    "abc?alt=media&x=1",
+    "http://evil.test/",
+  ])("rejects a fileId containing %j rather than fetching it", async (fileId) => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await download(get(`?fileId=${encodeURIComponent(fileId)}`));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid fileId" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("proxies the video without exposing the API key to the client", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(8),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await download(get("?fileId=files_abc-123"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("video/mp4");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta/files/files_abc-123?alt=media",
+      { headers: { "x-goog-api-key": "goog-key" } }
+    );
+  });
+
+  it("answers 500 when no API key is configured", async () => {
+    settings.mockResolvedValue({ videoApiKey: "" } as never);
+    const response = await download(get("?fileId=abc"));
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "No API key configured" });
+  });
+
+  it("passes the upstream status through when the download fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    const response = await download(get("?fileId=abc"));
+    expect(response.status).toBe(404);
+  });
+
+  it("answers 401 when signed out", async () => {
+    session.mockRejectedValue(new Error("Unauthorized"));
+    expect((await download(get("?fileId=abc"))).status).toBe(401);
+  });
+});

--- a/tests/fixtures/brand-dna.ts
+++ b/tests/fixtures/brand-dna.ts
@@ -1,0 +1,46 @@
+import type { BrandDNA } from "@/lib/brand-dna/types";
+
+/**
+ * A complete BrandDNA, so tests can override just the field under test:
+ *
+ *   makeBrandDNA({ colors: [] })
+ */
+export function makeBrandDNA(overrides: Partial<BrandDNA> = {}): BrandDNA {
+  return {
+    name: "Acme Coffee",
+    tagline: "Roasted with intent",
+    url: "https://acme.coffee",
+    logoUrl: "https://acme.coffee/logo.svg",
+    favicon: "https://acme.coffee/favicon.ico",
+    ogImage: null,
+    logos: [],
+    colors: [
+      { hex: "#6F4E37", name: "Brown", usage: "primary", rgb: [111, 78, 55] },
+      { hex: "#C0A080", name: "Orange", usage: "secondary", rgb: [192, 160, 128] },
+    ],
+    fonts: [
+      { family: "Playfair Display", usage: "heading", weight: "700" },
+      { family: "Inter", usage: "body", weight: "400" },
+    ],
+    tone: {
+      primary: "friendly",
+      secondary: "inspirational",
+      description: "Warm and unpretentious",
+      formality: 30,
+      energy: 70,
+      warmth: 85,
+    },
+    audience: {
+      primary: "Home brewers",
+      secondary: "Cafe owners",
+      ageRange: "25-45",
+      interests: ["specialty coffee", "sustainability"],
+      painPoints: ["stale beans", "inconsistent extraction"],
+    },
+    industry: "Food & Beverage",
+    category: "Coffee Roaster",
+    keywords: ["single origin", "small batch"],
+    rawText: "Acme Coffee roasts single origin beans in small batches.",
+    ...overrides,
+  };
+}

--- a/tests/lib/auth/options.test.ts
+++ b/tests/lib/auth/options.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({ prisma: { user: { findUnique: vi.fn() } } }));
+vi.mock("@next-auth/prisma-adapter", () => ({ PrismaAdapter: vi.fn(() => ({})) }));
+vi.mock("bcryptjs", () => ({ default: { compare: vi.fn() } }));
+
+import { prisma } from "@/lib/db";
+import bcrypt from "bcryptjs";
+
+const user = vi.mocked(prisma.user);
+const compare = vi.mocked(bcrypt.compare);
+
+type Authorize = (c?: { email: string; password: string }) => Promise<unknown>;
+
+async function loadOptions() {
+  vi.resetModules();
+  const { authOptions } = await import("@/lib/auth/options");
+  return authOptions;
+}
+
+async function loadAuthorize(): Promise<Authorize> {
+  const options = await loadOptions();
+  const credentials = options.providers.find((p) => p.id === "credentials")!;
+  return (credentials as unknown as { options: { authorize: Authorize } }).options.authorize;
+}
+
+beforeEach(() => {
+  compare.mockResolvedValue(true as never);
+  user.findUnique.mockResolvedValue({
+    id: "user_1",
+    email: "ada@example.com",
+    name: "Ada",
+    password: "hashed",
+  } as never);
+});
+
+describe("authOptions", () => {
+  it("uses stateless JWT sessions and the custom login page", async () => {
+    const options = await loadOptions();
+    expect(options.session?.strategy).toBe("jwt");
+    expect(options.pages?.signIn).toBe("/login");
+  });
+
+  it("omits the Google provider unless it is configured", async () => {
+    const options = await loadOptions();
+    expect(options.providers.map((p) => p.id)).toEqual(["credentials"]);
+  });
+
+  it("adds the Google provider when GOOGLE_CLIENT_ID is set", async () => {
+    vi.stubEnv("GOOGLE_CLIENT_ID", "google-id");
+    vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-secret");
+
+    const options = await loadOptions();
+
+    expect(options.providers.map((p) => p.id)).toContain("google");
+  });
+});
+
+describe("credentials authorize", () => {
+  it("returns the user when the password matches", async () => {
+    const authorize = await loadAuthorize();
+
+    await expect(authorize({ email: "ada@example.com", password: "pw" })).resolves.toEqual({
+      id: "user_1",
+      email: "ada@example.com",
+      name: "Ada",
+    });
+  });
+
+  it("never returns the password hash", async () => {
+    const authorize = await loadAuthorize();
+    const result = await authorize({ email: "ada@example.com", password: "pw" });
+    expect(result).not.toHaveProperty("password");
+  });
+
+  it("compares against the stored hash rather than the raw value", async () => {
+    const authorize = await loadAuthorize();
+    await authorize({ email: "ada@example.com", password: "pw" });
+    expect(compare).toHaveBeenCalledWith("pw", "hashed");
+  });
+
+  it.each([
+    ["no credentials at all", undefined],
+    ["a missing email", { email: "", password: "pw" }],
+    ["a missing password", { email: "ada@example.com", password: "" }],
+  ])("rejects %s", async (_label, credentials) => {
+    const authorize = await loadAuthorize();
+    await expect(authorize(credentials)).rejects.toThrow("Missing credentials");
+    expect(user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("gives the same error for an unknown email as for a wrong password", async () => {
+    const authorize = await loadAuthorize();
+
+    user.findUnique.mockResolvedValue(null as never);
+    const unknownEmail = await authorize({ email: "nobody@example.com", password: "pw" }).catch(
+      (e: Error) => e.message
+    );
+
+    user.findUnique.mockResolvedValue({ id: "u", email: "a", name: "A", password: "hashed" } as never);
+    compare.mockResolvedValue(false as never);
+    const wrongPassword = await authorize({ email: "ada@example.com", password: "nope" }).catch(
+      (e: Error) => e.message
+    );
+
+    expect(unknownEmail).toBe("Invalid credentials");
+    expect(wrongPassword).toBe("Invalid credentials");
+  });
+
+  it("rejects an account that has no password set, such as a Google-only user", async () => {
+    user.findUnique.mockResolvedValue({ id: "u", email: "a", name: "A", password: null } as never);
+    const authorize = await loadAuthorize();
+
+    await expect(authorize({ email: "a", password: "pw" })).rejects.toThrow("Invalid credentials");
+    expect(compare).not.toHaveBeenCalled();
+  });
+});
+
+describe("callbacks", () => {
+  it("puts the user id on the session", async () => {
+    const options = await loadOptions();
+
+    const session = await options.callbacks!.session!({
+      session: { user: { email: "a@b.c" }, expires: "" },
+      token: { sub: "user_1" },
+    } as never);
+
+    expect((session.user as { id: string }).id).toBe("user_1");
+  });
+
+  it("leaves the session alone when the token has no subject", async () => {
+    const options = await loadOptions();
+
+    const session = await options.callbacks!.session!({
+      session: { user: { email: "a@b.c" }, expires: "" },
+      token: {},
+    } as never);
+
+    expect(session.user).not.toHaveProperty("id");
+  });
+
+  it("copies the user id onto the token at sign-in", async () => {
+    const options = await loadOptions();
+
+    const token = await options.callbacks!.jwt!({
+      token: {},
+      user: { id: "user_1" },
+    } as never);
+
+    expect(token.sub).toBe("user_1");
+  });
+
+  it("leaves the token untouched on later requests", async () => {
+    const options = await loadOptions();
+
+    const token = await options.callbacks!.jwt!({ token: { sub: "existing" } } as never);
+
+    expect(token.sub).toBe("existing");
+  });
+});

--- a/tests/lib/auth/session.test.ts
+++ b/tests/lib/auth/session.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/auth/options", () => ({ authOptions: { providers: [] } }));
+
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth/options";
+import { getSession, requireSession } from "@/lib/auth/session";
+
+const serverSession = vi.mocked(getServerSession);
+
+beforeEach(() => {
+  serverSession.mockResolvedValue(null as never);
+});
+
+describe("getSession", () => {
+  it("reads the session using the app's auth options", async () => {
+    await getSession();
+    expect(serverSession).toHaveBeenCalledWith(authOptions);
+  });
+
+  it("returns whatever next-auth returns", async () => {
+    serverSession.mockResolvedValue({ user: { id: "user_1" } } as never);
+    await expect(getSession()).resolves.toEqual({ user: { id: "user_1" } });
+  });
+});
+
+describe("requireSession", () => {
+  it("returns the session when a user is signed in", async () => {
+    serverSession.mockResolvedValue({ user: { id: "user_1", email: "a@b.c" } } as never);
+    await expect(requireSession()).resolves.toMatchObject({ user: { id: "user_1" } });
+  });
+
+  it("throws Unauthorized when there is no session", async () => {
+    await expect(requireSession()).rejects.toThrow("Unauthorized");
+  });
+
+  it("throws Unauthorized when the session carries no user", async () => {
+    serverSession.mockResolvedValue({} as never);
+    await expect(requireSession()).rejects.toThrow("Unauthorized");
+  });
+});

--- a/tests/lib/brand-dna/color-extractor.test.ts
+++ b/tests/lib/brand-dna/color-extractor.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { extractColorsFromCSS } from "@/lib/brand-dna/color-extractor";
+
+describe("extractColorsFromCSS", () => {
+  it("returns nothing when the CSS contains no colours", () => {
+    expect(extractColorsFromCSS([])).toEqual([]);
+    expect(extractColorsFromCSS(["font-size: 14px", "margin: 0 auto"])).toEqual([]);
+  });
+
+  it("extracts hex colours and normalises them to uppercase", () => {
+    const [color] = extractColorsFromCSS(["color: #ff5733"]);
+    expect(color.hex).toBe("#FF5733");
+  });
+
+  it("expands three-digit shorthand hex", () => {
+    const [color] = extractColorsFromCSS(["color: #f00"]);
+    expect(color.hex).toBe("#FF0000");
+    expect(color.rgb).toEqual([255, 0, 0]);
+  });
+
+  it("drops the alpha channel from eight-digit hex", () => {
+    const [color] = extractColorsFromCSS(["color: #ff573380"]);
+    expect(color.hex).toBe("#FF5733");
+  });
+
+  it("parses rgb() and rgba() notation", () => {
+    const [color] = extractColorsFromCSS(["color: rgb(255, 87, 51)"]);
+    expect(color.hex).toBe("#FF5733");
+
+    const [alpha] = extractColorsFromCSS(["color: rgba(255, 87, 51, 0.5)"]);
+    expect(alpha.hex).toBe("#FF5733");
+  });
+
+  it("treats the same colour written two ways as one colour", () => {
+    const colors = extractColorsFromCSS(["color: #ff5733", "border-color: rgb(255, 87, 51)"]);
+    expect(colors).toHaveLength(1);
+  });
+
+  it("orders colours by how often they appear", () => {
+    const colors = extractColorsFromCSS([
+      "a { color: #1188ff }",
+      "b { color: #1188ff }",
+      "c { color: #1188ff }",
+      "d { color: #ff8811 }",
+      "e { color: #ff8811 }",
+      "f { color: #22bb22 }",
+    ]);
+
+    expect(colors.map((c) => c.hex)).toEqual(["#1188FF", "#FF8811", "#22BB22"]);
+  });
+
+  it("filters out near-white, near-black and washed-out colours", () => {
+    const colors = extractColorsFromCSS([
+      "color: #FFFFFF",
+      "color: #000000",
+      "color: #FEFEFE",
+      "color: #010101",
+      "color: #EFEFEF",
+      "color: #1188FF",
+    ]);
+
+    expect(colors.map((c) => c.hex)).toEqual(["#1188FF"]);
+  });
+
+  it("keeps at most six colours", () => {
+    const css = ["#1188FF", "#FF8811", "#22BB22", "#BB22BB", "#22BBBB", "#BBBB22", "#884422"].map(
+      (hex) => `color: ${hex}`
+    );
+
+    expect(extractColorsFromCSS(css)).toHaveLength(6);
+  });
+
+  it("assigns usage by position, with the last colour treated as text", () => {
+    const css = ["#1188FF", "#FF8811", "#22BB22", "#BB22BB", "#22BBBB", "#BBBB22"].map(
+      (hex, i) => Array(10 - i).fill(`color: ${hex}`).join(" ")
+    );
+
+    expect(extractColorsFromCSS(css).map((c) => c.usage)).toEqual([
+      "primary",
+      "secondary",
+      "accent",
+      "background",
+      "background",
+      "text",
+    ]);
+  });
+
+  it("names colours by hue", () => {
+    const nameOf = (hex: string) => extractColorsFromCSS([`color: ${hex}`])[0].name;
+
+    expect(nameOf("#FF0000")).toBe("Red");
+    expect(nameOf("#FF8800")).toBe("Orange");
+    expect(nameOf("#22BB22")).toBe("Green");
+    expect(nameOf("#1188FF")).toBe("Blue");
+    expect(nameOf("#8822BB")).toBe("Purple");
+    expect(nameOf("#888888")).toBe("Gray");
+  });
+
+  it("returns the rgb triple alongside the hex", () => {
+    const [color] = extractColorsFromCSS(["color: #1188FF"]);
+    expect(color.rgb).toEqual([17, 136, 255]);
+  });
+});

--- a/tests/lib/brand-dna/crawler.test.ts
+++ b/tests/lib/brand-dna/crawler.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { launch } = vi.hoisted(() => ({ launch: vi.fn() }));
+
+vi.mock("playwright", () => ({ chromium: { launch } }));
+vi.mock("@/lib/llm/client", () => ({ generateJSON: vi.fn() }));
+
+import { generateJSON } from "@/lib/llm/client";
+import { crawlBrandDNA } from "@/lib/brand-dna/crawler";
+
+const llm = vi.mocked(generateJSON);
+
+const META = {
+  name: "Acme Coffee",
+  description: "Roasted with intent",
+  logoUrl: "https://acme.coffee/logo.svg",
+  favicon: "https://acme.coffee/favicon.ico",
+  ogImage: null,
+};
+
+const ANALYSIS = {
+  tone: {
+    primary: "friendly",
+    secondary: "inspirational",
+    description: "Warm",
+    formality: 30,
+    energy: 70,
+    warmth: 85,
+  },
+  audience: {
+    primary: "Home brewers",
+    secondary: "Cafe owners",
+    ageRange: "25-45",
+    interests: ["coffee"],
+    painPoints: ["stale beans"],
+  },
+  industry: "Food & Beverage",
+  category: "Coffee Roaster",
+  keywords: ["single origin"],
+};
+
+const goto = vi.fn();
+const close = vi.fn();
+const evaluate = vi.fn();
+
+/** page.evaluate is called in a fixed order by crawlBrandDNA. */
+function stubPage({
+  meta = META,
+  cssColors = ["color: #6F4E37", "color: #C0A080"],
+  fonts = [{ family: "Playfair Display", tag: "h1", weight: "700" }],
+  logos = [{ url: "https://acme.coffee/logo.svg", alt: "Acme" }],
+  text = "Acme Coffee roasts single origin beans.",
+} = {}) {
+  evaluate
+    .mockResolvedValueOnce(meta)
+    .mockResolvedValueOnce(cssColors)
+    .mockResolvedValueOnce(fonts)
+    .mockResolvedValueOnce(logos)
+    .mockResolvedValueOnce(text);
+}
+
+beforeEach(() => {
+  goto.mockResolvedValue(undefined);
+  close.mockResolvedValue(undefined);
+  launch.mockResolvedValue({
+    newContext: vi.fn().mockResolvedValue({
+      newPage: vi.fn().mockResolvedValue({ goto, evaluate, waitForTimeout: vi.fn() }),
+    }),
+    close,
+  });
+  llm.mockResolvedValue(ANALYSIS as never);
+});
+
+describe("crawlBrandDNA", () => {
+  it("returns a complete brand profile", async () => {
+    stubPage();
+
+    const dna = await crawlBrandDNA("https://acme.coffee");
+
+    expect(dna).toMatchObject({
+      name: "Acme Coffee",
+      tagline: "Roasted with intent",
+      url: "https://acme.coffee",
+      logoUrl: "https://acme.coffee/logo.svg",
+      industry: "Food & Beverage",
+      category: "Coffee Roaster",
+    });
+    expect(dna.colors.map((c) => c.hex)).toEqual(["#6F4E37", "#C0A080"]);
+    expect(dna.fonts[0].family).toBe("Playfair Display");
+  });
+
+  it("launches a headless browser and visits the URL", async () => {
+    stubPage();
+
+    await crawlBrandDNA("https://acme.coffee");
+
+    expect(launch).toHaveBeenCalledWith(expect.objectContaining({ headless: true }));
+    expect(goto).toHaveBeenCalledWith(
+      "https://acme.coffee",
+      expect.objectContaining({ waitUntil: "networkidle" })
+    );
+  });
+
+  it("honours PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH for the container build", async () => {
+    vi.stubEnv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH", "/usr/bin/chromium-browser");
+    stubPage();
+
+    await crawlBrandDNA("https://acme.coffee");
+
+    expect(launch).toHaveBeenCalledWith(
+      expect.objectContaining({ executablePath: "/usr/bin/chromium-browser" })
+    );
+  });
+
+  it("reports progress for each step", async () => {
+    stubPage();
+    const steps: string[] = [];
+
+    await crawlBrandDNA("https://acme.coffee", (p) => {
+      if (p.status === "running") steps.push(p.step);
+    });
+
+    expect(steps).toEqual([
+      "Launching browser",
+      "Crawling site",
+      "Extracting metadata",
+      "Extracting colors",
+      "Extracting fonts",
+      "Extracting logos",
+      "Extracting content",
+      "Analyzing tone",
+    ]);
+  });
+
+  it("always closes the browser, even when the crawl fails", async () => {
+    goto.mockRejectedValue(new Error("net::ERR_NAME_NOT_RESOLVED"));
+
+    await expect(crawlBrandDNA("https://nope.invalid")).rejects.toThrow("ERR_NAME_NOT_RESOLVED");
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("closes the browser after a successful crawl", async () => {
+    stubPage();
+    await crawlBrandDNA("https://acme.coffee");
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("falls back to the hostname when the page has no title", async () => {
+    stubPage({ meta: { ...META, name: "" } });
+
+    const dna = await crawlBrandDNA("https://acme.coffee");
+
+    expect(dna.name).toBe("acme.coffee");
+  });
+
+  it("uses an empty tagline when there is no description", async () => {
+    stubPage({ meta: { ...META, description: "" } });
+
+    expect((await crawlBrandDNA("https://acme.coffee")).tagline).toBe("");
+  });
+
+  it("still returns a profile when the LLM analysis fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    stubPage();
+    llm.mockRejectedValue(new Error("model unavailable"));
+
+    const dna = await crawlBrandDNA("https://acme.coffee");
+
+    expect(dna.name).toBe("Acme Coffee");
+    expect(dna.tone.primary).toBeTruthy();
+    expect(dna.industry).toBeTruthy();
+  });
+
+  it("reports the LLM failure through the progress callback", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    stubPage();
+    llm.mockRejectedValue(new Error("model unavailable"));
+
+    const events: { step: string; status: string; detail?: string }[] = [];
+    await crawlBrandDNA("https://acme.coffee", (p) => events.push(p));
+
+    const toneStep = events.find((e) => e.step === "Analyzing tone" && e.status === "error");
+    expect(toneStep?.detail).toContain("model unavailable");
+  });
+
+  it("caps the raw text it keeps", async () => {
+    stubPage({ text: "x".repeat(5000) });
+
+    expect((await crawlBrandDNA("https://acme.coffee")).rawText).toHaveLength(2000);
+  });
+
+  it("works on a site with no colours or fonts to find", async () => {
+    stubPage({ cssColors: [], fonts: [], logos: [] });
+
+    const dna = await crawlBrandDNA("https://acme.coffee");
+
+    expect(dna.colors).toEqual([]);
+    expect(dna.fonts).toEqual([]);
+    expect(dna.logos).toEqual([]);
+  });
+});

--- a/tests/lib/brand-dna/font-extractor.test.ts
+++ b/tests/lib/brand-dna/font-extractor.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { extractFonts } from "@/lib/brand-dna/font-extractor";
+
+const font = (family: string, tag: string, weight = "400") => ({ family, tag, weight });
+
+describe("extractFonts", () => {
+  it("returns nothing for no input", () => {
+    expect(extractFonts([])).toEqual([]);
+  });
+
+  it("takes the first non-generic family from a font stack", () => {
+    const fonts = extractFonts([font('"Playfair Display", Georgia, serif', "h1")]);
+    expect(fonts).toEqual([{ family: "Playfair Display", usage: "heading", weight: "400" }]);
+  });
+
+  it("strips quotes from family names", () => {
+    expect(extractFonts([font("'Inter', sans-serif", "p")])[0].family).toBe("Inter");
+  });
+
+  it("ignores stacks made up entirely of generic or system fonts", () => {
+    const fonts = extractFonts([
+      font("Arial, Helvetica, sans-serif", "p"),
+      font("-apple-system, BlinkMacSystemFont, 'Segoe UI'", "h1"),
+      font("monospace", "code"),
+    ]);
+    expect(fonts).toEqual([]);
+  });
+
+  it("classifies a family used in a heading as a heading font", () => {
+    for (const tag of ["h1", "h2", "h3"]) {
+      expect(extractFonts([font("Playfair Display", tag)])[0].usage).toBe("heading");
+    }
+  });
+
+  it("classifies a family used on interactive elements as an accent font", () => {
+    for (const tag of ["button", "a", "nav"]) {
+      expect(extractFonts([font("Inter", tag)])[0].usage).toBe("accent");
+    }
+  });
+
+  it("falls back to body for anything else", () => {
+    expect(extractFonts([font("Inter", "p")])[0].usage).toBe("body");
+  });
+
+  it("prefers heading over accent when a family is used for both", () => {
+    const fonts = extractFonts([font("Inter", "button"), font("Inter", "h2")]);
+    expect(fonts).toHaveLength(1);
+    expect(fonts[0].usage).toBe("heading");
+  });
+
+  it("is case-insensitive about tags", () => {
+    expect(extractFonts([font("Playfair Display", "H1")])[0].usage).toBe("heading");
+  });
+
+  it("keeps the weight from the first occurrence of a family", () => {
+    const fonts = extractFonts([font("Inter", "p", "400"), font("Inter", "h1", "700")]);
+    expect(fonts[0].weight).toBe("400");
+  });
+
+  it("returns at most three fonts, in the order they were first seen", () => {
+    const fonts = extractFonts([
+      font("One", "p"),
+      font("Two", "p"),
+      font("Three", "p"),
+      font("Four", "h1"),
+    ]);
+
+    expect(fonts.map((f) => f.family)).toEqual(["One", "Two", "Three"]);
+  });
+});

--- a/tests/lib/campaigns/generator.test.ts
+++ b/tests/lib/campaigns/generator.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/llm/client", () => ({ generateJSON: vi.fn(), streamText: vi.fn() }));
+
+import { generateJSON, streamText } from "@/lib/llm/client";
+import { generateCampaign, streamCampaign } from "@/lib/campaigns/generator";
+import { buildCampaignPrompt } from "@/lib/campaigns/prompt-builder";
+import { makeBrandDNA } from "../../fixtures/brand-dna";
+
+const json = vi.mocked(generateJSON);
+const stream = vi.mocked(streamText);
+const dna = makeBrandDNA();
+
+describe("generateCampaign", () => {
+  beforeEach(() => {
+    json.mockResolvedValue({ concepts: [] } as never);
+  });
+
+  it("returns whatever the model produced", async () => {
+    json.mockResolvedValue({ concepts: [{ name: "Launch" }] } as never);
+    await expect(generateCampaign(dna, "goal", ["instagram"])).resolves.toEqual({
+      concepts: [{ name: "Launch" }],
+    });
+  });
+
+  it("sends the campaign prompt built from the brand", async () => {
+    await generateCampaign(dna, "Launch cold brew", ["instagram", "linkedin"], "Arabic");
+
+    const messages = json.mock.calls[0][0] as { role: string; content: string }[];
+    expect(messages[0].role).toBe("system");
+    expect(messages[1].content).toBe(
+      buildCampaignPrompt(dna, "Launch cold brew", ["instagram", "linkedin"], "Arabic")
+    );
+  });
+
+  it("defaults to English", async () => {
+    await generateCampaign(dna, "goal", ["instagram"]);
+
+    const messages = json.mock.calls[0][0] as { content: string }[];
+    expect(messages[1].content).toContain("LANGUAGE: English");
+  });
+
+  it("asks for JSON with room for a long response", async () => {
+    await generateCampaign(dna, "goal", ["instagram"]);
+    expect(json).toHaveBeenCalledWith(expect.anything(), {
+      maxTokens: 8192,
+      temperature: 0.8,
+      json: true,
+    });
+  });
+});
+
+describe("streamCampaign", () => {
+  it("passes the model's chunks straight through", async () => {
+    stream.mockImplementation(async function* () {
+      yield "{";
+      yield '"concepts":[]}';
+    } as never);
+
+    const chunks = [];
+    for await (const chunk of streamCampaign(dna, "goal", ["instagram"])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join("")).toBe('{"concepts":[]}');
+  });
+
+  it("streams with the same options as the non-streaming path", async () => {
+    stream.mockImplementation(async function* () {} as never);
+
+    for await (const _ of streamCampaign(dna, "goal", ["instagram"])) {
+      // drain
+    }
+
+    expect(stream).toHaveBeenCalledWith(expect.anything(), {
+      maxTokens: 8192,
+      temperature: 0.8,
+      json: true,
+    });
+  });
+});

--- a/tests/lib/campaigns/prompt-builder.test.ts
+++ b/tests/lib/campaigns/prompt-builder.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBrandContext,
+  buildCampaignPrompt,
+  buildImagePrompt,
+} from "@/lib/campaigns/prompt-builder";
+import { makeBrandDNA } from "../../fixtures/brand-dna";
+
+describe("buildBrandContext", () => {
+  it("includes the brand identity", () => {
+    const context = buildBrandContext(makeBrandDNA());
+    expect(context).toContain("Name: Acme Coffee");
+    expect(context).toContain("Tagline: Roasted with intent");
+    expect(context).toContain("Industry: Food & Beverage / Coffee Roaster");
+  });
+
+  it("renders colours as name and hex", () => {
+    expect(buildBrandContext(makeBrandDNA())).toContain(
+      "Brand Colors: Brown (#6F4E37), Orange (#C0A080)"
+    );
+  });
+
+  it("renders fonts as family and usage", () => {
+    expect(buildBrandContext(makeBrandDNA())).toContain(
+      "Typography: Playfair Display (heading), Inter (body)"
+    );
+  });
+
+  it("includes the tone profile with its numeric dimensions", () => {
+    const context = buildBrandContext(makeBrandDNA());
+    expect(context).toContain("Tone: friendly (primary), inspirational (secondary)");
+    expect(context).toContain("Formality: 30/100");
+    expect(context).toContain("Energy: 70/100");
+    expect(context).toContain("Warmth: 85/100");
+  });
+
+  it("includes the audience and keywords", () => {
+    const context = buildBrandContext(makeBrandDNA());
+    expect(context).toContain("Home brewers (primary), Cafe owners (secondary)");
+    expect(context).toContain("Age Range: 25-45");
+    expect(context).toContain("Interests: specialty coffee, sustainability");
+    expect(context).toContain("Pain Points: stale beans, inconsistent extraction");
+    expect(context).toContain("Keywords: single origin, small batch");
+  });
+
+  it("survives a brand with no colours, fonts or keywords", () => {
+    const context = buildBrandContext(
+      makeBrandDNA({ colors: [], fonts: [], keywords: [] })
+    );
+    expect(context).toContain("Brand Colors: ");
+    expect(context).toContain("Typography: ");
+  });
+});
+
+describe("buildCampaignPrompt", () => {
+  const dna = makeBrandDNA();
+
+  it("embeds the brand context", () => {
+    const prompt = buildCampaignPrompt(dna, "Launch cold brew", ["instagram"]);
+    expect(prompt).toContain(buildBrandContext(dna));
+  });
+
+  it("includes the goal and the requested platforms", () => {
+    const prompt = buildCampaignPrompt(dna, "Launch cold brew", ["instagram", "linkedin"]);
+    expect(prompt).toContain("CAMPAIGN GOAL: Launch cold brew");
+    expect(prompt).toContain("TARGET PLATFORMS: instagram, linkedin");
+  });
+
+  it("defaults to English", () => {
+    expect(buildCampaignPrompt(dna, "goal", ["instagram"])).toContain("LANGUAGE: English");
+  });
+
+  it("honours a requested language, including in the rules", () => {
+    const prompt = buildCampaignPrompt(dna, "goal", ["instagram"], "Arabic");
+    expect(prompt).toContain("LANGUAGE: Arabic");
+    expect(prompt).toContain("All content must be in Arabic");
+  });
+
+  it("tells the model to use the brand's actual colours in image prompts", () => {
+    const prompt = buildCampaignPrompt(dna, "goal", ["instagram"]);
+    expect(prompt).toContain("#6F4E37, #C0A080");
+  });
+
+  it("carries the brand tone into the rules", () => {
+    expect(buildCampaignPrompt(dna, "goal", ["instagram"])).toContain(
+      "All content must match the brand's friendly tone"
+    );
+  });
+
+  it("asks for the JSON shape the generator parses", () => {
+    const prompt = buildCampaignPrompt(dna, "goal", ["instagram"]);
+    expect(prompt).toContain('"concepts"');
+    expect(prompt).toContain('"imagePrompt"');
+    expect(prompt).toContain("Generate exactly 5 campaign concepts");
+  });
+});
+
+describe("buildImagePrompt", () => {
+  it("uses the brand's first two colours", () => {
+    const prompt = buildImagePrompt(makeBrandDNA(), "Harvest", "instagram");
+    expect(prompt).toContain("Primary color: #6F4E37");
+    expect(prompt).toContain("Secondary color: #C0A080");
+  });
+
+  it("falls back to default colours when the brand has none", () => {
+    const prompt = buildImagePrompt(makeBrandDNA({ colors: [] }), "Harvest", "instagram");
+    expect(prompt).toContain("Primary color: #6366F1");
+    expect(prompt).toContain("Secondary color: #818CF8");
+  });
+
+  it("falls back for the secondary colour only when there is just one", () => {
+    const dna = makeBrandDNA({
+      colors: [{ hex: "#6F4E37", name: "Brown", usage: "primary", rgb: [111, 78, 55] }],
+    });
+    const prompt = buildImagePrompt(dna, "Harvest", "instagram");
+    expect(prompt).toContain("Primary color: #6F4E37");
+    expect(prompt).toContain("Secondary color: #818CF8");
+  });
+
+  it("picks the right dimensions per platform", () => {
+    const dna = makeBrandDNA();
+    expect(buildImagePrompt(dna, "t", "instagram")).toContain("1080x1080 square");
+    expect(buildImagePrompt(dna, "t", "facebook")).toContain("1200x630 landscape");
+    expect(buildImagePrompt(dna, "t", "linkedin")).toContain("1200x627 landscape");
+    expect(buildImagePrompt(dna, "t", "twitter")).toContain("1600x900 landscape");
+  });
+
+  it("falls back to a square for an unknown platform", () => {
+    expect(buildImagePrompt(makeBrandDNA(), "t", "pinterest")).toContain("1080x1080 square");
+  });
+
+  it("includes the concept theme, industry and tone", () => {
+    const prompt = buildImagePrompt(makeBrandDNA(), "Harvest", "instagram");
+    expect(prompt).toContain("Theme: Harvest");
+    expect(prompt).toContain("Industry: Food & Beverage");
+    expect(prompt).toContain("friendly, inspirational marketing image for Acme Coffee");
+  });
+
+  it("tells the model to keep text out of the image", () => {
+    expect(buildImagePrompt(makeBrandDNA(), "t", "instagram")).toContain(
+      "Do NOT include any text in the image"
+    );
+  });
+});

--- a/tests/lib/image/client.test.ts
+++ b/tests/lib/image/client.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveSettings = vi.fn();
+vi.mock("@/lib/settings/resolve", () => ({ resolveSettings }));
+
+const OpenAIImageProvider = vi.fn();
+const StabilityProvider = vi.fn();
+const ReplicateProvider = vi.fn();
+const GeminiImageProvider = vi.fn();
+
+vi.mock("@/lib/image/providers/openai", () => ({ OpenAIImageProvider }));
+vi.mock("@/lib/image/providers/stability", () => ({ StabilityProvider }));
+vi.mock("@/lib/image/providers/replicate", () => ({ ReplicateProvider }));
+vi.mock("@/lib/image/providers/gemini", () => ({ GeminiImageProvider }));
+
+const settings = (overrides: Record<string, string> = {}) => ({
+  llmProvider: "openai",
+  llmApiKey: "",
+  llmModel: "gpt-4o",
+  ollamaUrl: "http://localhost:11434",
+  imageProvider: "openai",
+  imageApiKey: "sk-image",
+  videoProvider: "veo",
+  videoApiKey: "",
+  ...overrides,
+});
+
+async function freshClient() {
+  vi.resetModules();
+  return import("@/lib/image/client");
+}
+
+describe("getImageProvider", () => {
+  beforeEach(() => {
+    // Block body on purpose: an arrow returning the mock would be treated by
+    // Vitest as a teardown callback and invoked after the test.
+    resolveSettings.mockResolvedValue(settings());
+  });
+
+  it.each([
+    ["openai", () => OpenAIImageProvider],
+    ["stability", () => StabilityProvider],
+    ["replicate", () => ReplicateProvider],
+    ["gemini", () => GeminiImageProvider],
+  ])("builds the %s provider with the resolved key", async (provider, ctor) => {
+    resolveSettings.mockResolvedValue(settings({ imageProvider: provider, imageApiKey: "key" }));
+    const { getImageProvider } = await freshClient();
+    await getImageProvider();
+    expect(ctor()).toHaveBeenCalledWith("key");
+  });
+
+  it("passes undefined rather than an empty key", async () => {
+    resolveSettings.mockResolvedValue(settings({ imageApiKey: "" }));
+    const { getImageProvider } = await freshClient();
+    await getImageProvider();
+    expect(OpenAIImageProvider).toHaveBeenCalledWith(undefined);
+  });
+
+  it("rejects an unknown provider by name", async () => {
+    resolveSettings.mockResolvedValue(settings({ imageProvider: "midjourney" }));
+    const { getImageProvider } = await freshClient();
+    await expect(getImageProvider()).rejects.toThrow("Unknown image provider: midjourney");
+  });
+
+  it("reuses the provider when nothing has changed", async () => {
+    const { getImageProvider } = await freshClient();
+    await getImageProvider();
+    await getImageProvider();
+    expect(OpenAIImageProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds when the key changes", async () => {
+    const { getImageProvider } = await freshClient();
+    await getImageProvider();
+    resolveSettings.mockResolvedValue(settings({ imageApiKey: "sk-rotated" }));
+    await getImageProvider();
+    expect(OpenAIImageProvider).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to IMAGE_PROVIDER when settings cannot be resolved", async () => {
+    resolveSettings.mockRejectedValue(new Error("no session"));
+    vi.stubEnv("IMAGE_PROVIDER", "stability");
+    const { getImageProvider } = await freshClient();
+    await getImageProvider();
+    expect(StabilityProvider).toHaveBeenCalledWith(undefined);
+  });
+
+  it("defaults to openai when nothing is configured at all", async () => {
+    resolveSettings.mockRejectedValue(new Error("no session"));
+    const { getImageProvider } = await freshClient();
+    await getImageProvider();
+    expect(OpenAIImageProvider).toHaveBeenCalled();
+  });
+});

--- a/tests/lib/image/providers.test.ts
+++ b/tests/lib/image/providers.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { imagesGenerate, openAICtor, getGenerativeModel, generateContent, geminiCtor } = vi.hoisted(
+  () => ({
+    imagesGenerate: vi.fn(),
+    openAICtor: vi.fn(),
+    getGenerativeModel: vi.fn(),
+    generateContent: vi.fn(),
+    geminiCtor: vi.fn(),
+  })
+);
+
+vi.mock("openai", () => ({
+  default: function (options: { apiKey?: string }) {
+    openAICtor(options);
+    return { images: { generate: imagesGenerate } };
+  },
+}));
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: function (apiKey: string) {
+    geminiCtor(apiKey);
+    return { getGenerativeModel };
+  },
+}));
+
+import { OpenAIImageProvider } from "@/lib/image/providers/openai";
+import { StabilityProvider } from "@/lib/image/providers/stability";
+import { ReplicateProvider } from "@/lib/image/providers/replicate";
+import { GeminiImageProvider } from "@/lib/image/providers/gemini";
+
+describe("OpenAIImageProvider", () => {
+  beforeEach(() => {
+    imagesGenerate.mockResolvedValue({ data: [{ url: "https://img/1.png" }] });
+  });
+
+  it("passes the key to the SDK and falls back to the environment", () => {
+    new OpenAIImageProvider("sk-explicit");
+    expect(openAICtor).toHaveBeenCalledWith({ apiKey: "sk-explicit" });
+
+    vi.stubEnv("OPENAI_API_KEY", "sk-env");
+    new OpenAIImageProvider();
+    expect(openAICtor).toHaveBeenLastCalledWith({ apiKey: "sk-env" });
+  });
+
+  it("asks DALL-E 3 for a single standard-quality image", async () => {
+    await new OpenAIImageProvider("sk").generate("a mug");
+
+    expect(imagesGenerate).toHaveBeenCalledWith({
+      model: "dall-e-3",
+      prompt: "a mug",
+      n: 1,
+      size: "1024x1024",
+      quality: "standard",
+    });
+  });
+
+  it("passes the requested size through", async () => {
+    await new OpenAIImageProvider("sk").generate("a mug", { size: "1792x1024" });
+    expect(imagesGenerate).toHaveBeenCalledWith(expect.objectContaining({ size: "1792x1024" }));
+  });
+
+  it("returns the generated URL", async () => {
+    await expect(new OpenAIImageProvider("sk").generate("a mug")).resolves.toEqual({
+      url: "https://img/1.png",
+    });
+  });
+
+  it("throws when the API returns no image", async () => {
+    imagesGenerate.mockResolvedValue({ data: [] });
+    await expect(new OpenAIImageProvider("sk").generate("a mug")).rejects.toThrow(
+      "No image URL returned from DALL-E"
+    );
+  });
+});
+
+describe("StabilityProvider", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ image: "BASE64DATA" }) });
+  });
+
+  it("refuses to construct without a key", () => {
+    expect(() => new StabilityProvider()).toThrow("STABILITY_API_KEY is not set");
+  });
+
+  it("accepts a key from the environment", () => {
+    vi.stubEnv("STABILITY_API_KEY", "sk-env");
+    expect(() => new StabilityProvider()).not.toThrow();
+  });
+
+  it("sends the prompt as multipart form data with a bearer token", async () => {
+    await new StabilityProvider("sk").generate("a mug");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.stability.ai/v2beta/stable-image/generate/core");
+    expect(init.headers.Authorization).toBe("Bearer sk");
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get("prompt")).toBe("a mug");
+  });
+
+  it.each([
+    ["1024x1024", "1:1"],
+    ["1024x1792", "9:16"],
+    ["1792x1024", "16:9"],
+  ])("maps size %s to aspect ratio %s", async (size, ratio) => {
+    await new StabilityProvider("sk").generate("a mug", { size: size as "1024x1024" });
+    const form = fetchMock.mock.calls[0][1].body as FormData;
+    expect(form.get("aspect_ratio")).toBe(ratio);
+  });
+
+  it("returns the image as a base64 data URL", async () => {
+    await expect(new StabilityProvider("sk").generate("a mug")).resolves.toEqual({
+      url: "data:image/jpeg;base64,BASE64DATA",
+    });
+  });
+
+  it("surfaces an API error with its status", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 402, text: async () => "payment required" });
+    await expect(new StabilityProvider("sk").generate("a mug")).rejects.toThrow(
+      "Stability AI error 402: payment required"
+    );
+  });
+
+  it("throws when the response carries no image", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    await expect(new StabilityProvider("sk").generate("a mug")).rejects.toThrow(
+      "No image returned from Stability AI"
+    );
+  });
+});
+
+describe("ReplicateProvider", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const submitReturns = (prediction: object) =>
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => prediction });
+  const pollReturns = (prediction: object) =>
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => prediction });
+
+  it("refuses to construct without a token", () => {
+    expect(() => new ReplicateProvider()).toThrow("REPLICATE_API_TOKEN is not set");
+  });
+
+  it("submits a prediction then polls until it succeeds", async () => {
+    submitReturns({ id: "pred_1", status: "starting" });
+    pollReturns({ id: "pred_1", status: "processing" });
+    pollReturns({ id: "pred_1", status: "succeeded", output: ["https://img/out.png"] });
+
+    const promise = new ReplicateProvider("r8").generate("a mug");
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(promise).resolves.toEqual({ url: "https://img/out.png" });
+    expect(fetchMock.mock.calls[1][0]).toBe("https://api.replicate.com/v1/predictions/pred_1");
+  });
+
+  it("sends the prompt and dimensions for the requested size", async () => {
+    submitReturns({ id: "p", status: "starting" });
+    pollReturns({ id: "p", status: "succeeded", output: ["https://img/o.png"] });
+
+    const promise = new ReplicateProvider("r8").generate("a mug", { size: "1024x1792" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      input: { prompt: "a mug", width: 1024, height: 1792 },
+    });
+  });
+
+  it("authenticates with a Token header", async () => {
+    submitReturns({ id: "p", status: "starting" });
+    pollReturns({ id: "p", status: "succeeded", output: ["https://img/o.png"] });
+
+    const promise = new ReplicateProvider("r8").generate("a mug");
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe("Token r8");
+  });
+
+  it("surfaces a submission error", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 401, text: async () => "unauthorized" });
+    await expect(new ReplicateProvider("r8").generate("a mug")).rejects.toThrow(
+      "Replicate error 401: unauthorized"
+    );
+  });
+
+  it.each(["failed", "canceled"])("throws when the prediction is %s", async (status) => {
+    submitReturns({ id: "p", status: "starting" });
+    pollReturns({ id: "p", status, error: "nsfw" });
+
+    const promise = new ReplicateProvider("r8").generate("a mug");
+    const assertion = expect(promise).rejects.toThrow(`Replicate prediction ${status}: nsfw`);
+    await vi.advanceTimersByTimeAsync(3000);
+    await assertion;
+  });
+
+  it("throws when a succeeded prediction has no output", async () => {
+    submitReturns({ id: "p", status: "starting" });
+    pollReturns({ id: "p", status: "succeeded", output: [] });
+
+    const promise = new ReplicateProvider("r8").generate("a mug");
+    const assertion = expect(promise).rejects.toThrow("No output URL from Replicate");
+    await vi.advanceTimersByTimeAsync(3000);
+    await assertion;
+  });
+
+  it("gives up after 60 seconds", async () => {
+    submitReturns({ id: "p", status: "starting" });
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ id: "p", status: "processing" }) });
+
+    const promise = new ReplicateProvider("r8").generate("a mug");
+    const assertion = expect(promise).rejects.toThrow("Replicate prediction timed out after 60s");
+    await vi.advanceTimersByTimeAsync(65_000);
+    await assertion;
+  });
+});
+
+describe("GeminiImageProvider", () => {
+  const imagePart = (mimeType: string, data: string) => ({
+    response: { candidates: [{ content: { parts: [{ inlineData: { mimeType, data } }] } }] },
+  });
+
+  beforeEach(() => {
+    generateContent.mockResolvedValue(imagePart("image/png", "BASE64"));
+    getGenerativeModel.mockReturnValue({ generateContent });
+  });
+
+  it("passes the key, falling back to GOOGLE_API_KEY", () => {
+    new GeminiImageProvider("goog");
+    expect(geminiCtor).toHaveBeenCalledWith("goog");
+
+    vi.stubEnv("GOOGLE_API_KEY", "goog-env");
+    new GeminiImageProvider();
+    expect(geminiCtor).toHaveBeenLastCalledWith("goog-env");
+  });
+
+  it("uses GEMINI_IMAGE_MODEL when set", async () => {
+    vi.stubEnv("GEMINI_IMAGE_MODEL", "gemini-image-2");
+    await new GeminiImageProvider("k").generate("a mug");
+    expect(getGenerativeModel).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gemini-image-2" })
+    );
+  });
+
+  it("asks for both text and image modalities", async () => {
+    await new GeminiImageProvider("k").generate("a mug");
+    expect(getGenerativeModel.mock.calls[0][0].generationConfig.responseModalities).toEqual([
+      "TEXT",
+      "IMAGE",
+    ]);
+  });
+
+  it.each([
+    [undefined, "1:1 square"],
+    ["1024x1792", "9:16 portrait"],
+    ["1792x1024", "16:9 landscape"],
+  ])("hints aspect ratio %s as %s", async (size, hint) => {
+    await new GeminiImageProvider("k").generate("a mug", size ? { size: size as "1024x1792" } : undefined);
+    expect(generateContent).toHaveBeenCalledWith(`Generate an image: a mug. Aspect ratio: ${hint}`);
+  });
+
+  it("returns the inline image as a data URL", async () => {
+    generateContent.mockResolvedValue(imagePart("image/webp", "WEBPDATA"));
+    await expect(new GeminiImageProvider("k").generate("a mug")).resolves.toEqual({
+      url: "data:image/webp;base64,WEBPDATA",
+    });
+  });
+
+  it("skips text parts and finds the image", async () => {
+    generateContent.mockResolvedValue({
+      response: {
+        candidates: [
+          { content: { parts: [{ text: "Here you go" }, { inlineData: { mimeType: "image/png", data: "B64" } }] } },
+        ],
+      },
+    });
+
+    await expect(new GeminiImageProvider("k").generate("a mug")).resolves.toEqual({
+      url: "data:image/png;base64,B64",
+    });
+  });
+
+  it("throws when the model returns only text", async () => {
+    generateContent.mockResolvedValue({
+      response: { candidates: [{ content: { parts: [{ text: "I cannot" }] } }] },
+    });
+
+    await expect(new GeminiImageProvider("k").generate("a mug")).rejects.toThrow(
+      "Gemini did not return an image"
+    );
+  });
+
+  it("throws when there are no candidates at all", async () => {
+    generateContent.mockResolvedValue({ response: {} });
+    await expect(new GeminiImageProvider("k").generate("a mug")).rejects.toThrow(
+      "Gemini did not return an image"
+    );
+  });
+});

--- a/tests/lib/llm/client.test.ts
+++ b/tests/lib/llm/client.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveSettings = vi.fn();
+vi.mock("@/lib/settings/resolve", () => ({ resolveSettings }));
+
+const OpenAIProvider = vi.fn();
+const AnthropicProvider = vi.fn();
+const OllamaProvider = vi.fn();
+const GeminiProvider = vi.fn();
+
+vi.mock("@/lib/llm/providers/openai", () => ({ OpenAIProvider }));
+vi.mock("@/lib/llm/providers/anthropic", () => ({ AnthropicProvider }));
+vi.mock("@/lib/llm/providers/ollama", () => ({ OllamaProvider }));
+vi.mock("@/lib/llm/providers/gemini", () => ({ GeminiProvider }));
+
+const settings = (overrides: Record<string, string> = {}) => ({
+  llmProvider: "openai",
+  llmApiKey: "sk-test",
+  llmModel: "gpt-4o",
+  ollamaUrl: "http://localhost:11434",
+  imageProvider: "openai",
+  imageApiKey: "",
+  videoProvider: "veo",
+  videoApiKey: "",
+  ...overrides,
+});
+
+// client.ts memoises the provider at module scope, so each test needs a fresh
+// module registry to avoid inheriting the previous test's cached provider.
+async function freshClient() {
+  vi.resetModules();
+  return import("@/lib/llm/client");
+}
+
+describe("getLLMProvider", () => {
+  beforeEach(() => {
+    resolveSettings.mockResolvedValue(settings());
+  });
+
+  it("builds the provider named in the resolved settings", async () => {
+    const { getLLMProvider } = await freshClient();
+    await getLLMProvider();
+    expect(OpenAIProvider).toHaveBeenCalledWith("sk-test", "gpt-4o");
+  });
+
+  it.each([
+    ["anthropic", () => AnthropicProvider],
+    ["gemini", () => GeminiProvider],
+  ])("builds the %s provider with the resolved key and model", async (provider, ctor) => {
+    resolveSettings.mockResolvedValue(
+      settings({ llmProvider: provider, llmApiKey: "key", llmModel: "model" })
+    );
+    const { getLLMProvider } = await freshClient();
+    await getLLMProvider();
+    expect(ctor()).toHaveBeenCalledWith("key", "model");
+  });
+
+  it("builds ollama with the base URL rather than an API key", async () => {
+    resolveSettings.mockResolvedValue(
+      settings({ llmProvider: "ollama", llmApiKey: "", ollamaUrl: "http://ollama:11434", llmModel: "llama3.1" })
+    );
+    const { getLLMProvider } = await freshClient();
+    await getLLMProvider();
+    expect(OllamaProvider).toHaveBeenCalledWith("http://ollama:11434", "llama3.1");
+  });
+
+  it("rejects an unknown provider by name", async () => {
+    resolveSettings.mockResolvedValue(settings({ llmProvider: "hal9000" }));
+    const { getLLMProvider } = await freshClient();
+    await expect(getLLMProvider()).rejects.toThrow("Unknown LLM provider: hal9000");
+  });
+
+  it("reuses the provider when the settings have not changed", async () => {
+    const { getLLMProvider } = await freshClient();
+    await getLLMProvider();
+    await getLLMProvider();
+    expect(OpenAIProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds the provider when the API key changes", async () => {
+    const { getLLMProvider } = await freshClient();
+    await getLLMProvider();
+
+    resolveSettings.mockResolvedValue(settings({ llmApiKey: "sk-rotated" }));
+    await getLLMProvider();
+
+    expect(OpenAIProvider).toHaveBeenCalledTimes(2);
+    expect(OpenAIProvider).toHaveBeenLastCalledWith("sk-rotated", "gpt-4o");
+  });
+
+  it("rebuilds the provider when the model changes", async () => {
+    const { getLLMProvider } = await freshClient();
+    await getLLMProvider();
+
+    resolveSettings.mockResolvedValue(settings({ llmModel: "gpt-4o-mini" }));
+    await getLLMProvider();
+
+    expect(OpenAIProvider).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to LLM_PROVIDER when settings cannot be resolved", async () => {
+    resolveSettings.mockRejectedValue(new Error("no session"));
+    vi.stubEnv("LLM_PROVIDER", "anthropic");
+
+    const { getLLMProvider } = await freshClient();
+    await getLLMProvider();
+
+    expect(AnthropicProvider).toHaveBeenCalledWith(undefined, undefined);
+  });
+});
+
+describe("generateText", () => {
+  it("returns just the content of the provider response", async () => {
+    resolveSettings.mockResolvedValue(settings());
+    const generate = vi.fn().mockResolvedValue({ content: "hello" });
+    OpenAIProvider.mockImplementation(function () {
+      return { generate };
+    });
+
+    const { generateText } = await freshClient();
+    await expect(generateText([{ role: "user", content: "hi" }])).resolves.toBe("hello");
+    expect(generate).toHaveBeenCalledWith([{ role: "user", content: "hi" }], undefined);
+  });
+});
+
+describe("streamText", () => {
+  it("yields the content of each chunk", async () => {
+    resolveSettings.mockResolvedValue(settings());
+    OpenAIProvider.mockImplementation(function () {
+      return {
+        async *stream() {
+          yield { content: "Hel", done: false };
+          yield { content: "lo", done: true };
+        },
+      };
+    });
+
+    const { streamText } = await freshClient();
+    const chunks: string[] = [];
+    for await (const chunk of streamText([{ role: "user", content: "hi" }])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["Hel", "lo"]);
+  });
+});
+
+describe("generateJSON", () => {
+  const respondWith = (content: string) => {
+    resolveSettings.mockResolvedValue(settings());
+    OpenAIProvider.mockImplementation(function () {
+      return { generate: vi.fn().mockResolvedValue({ content }) };
+    });
+  };
+
+  it("parses a plain JSON response", async () => {
+    respondWith('{"concepts":[{"name":"Launch"}]}');
+    const { generateJSON } = await freshClient();
+    await expect(generateJSON([])).resolves.toEqual({ concepts: [{ name: "Launch" }] });
+  });
+
+  it("digs the object out of a fenced code block", async () => {
+    respondWith('Sure!\n```json\n{"ok":true}\n```\nHope that helps.');
+    const { generateJSON } = await freshClient();
+    await expect(generateJSON([])).resolves.toEqual({ ok: true });
+  });
+
+  it("asks the provider for JSON at temperature 0", async () => {
+    const generate = vi.fn().mockResolvedValue({ content: "{}" });
+    resolveSettings.mockResolvedValue(settings());
+    OpenAIProvider.mockImplementation(function () {
+      return { generate };
+    });
+
+    const { generateJSON } = await freshClient();
+    await generateJSON([{ role: "user", content: "hi" }]);
+
+    expect(generate).toHaveBeenCalledWith(
+      [{ role: "user", content: "hi" }],
+      expect.objectContaining({ json: true, temperature: 0 })
+    );
+  });
+
+  it("lets an explicit temperature through", async () => {
+    const generate = vi.fn().mockResolvedValue({ content: "{}" });
+    resolveSettings.mockResolvedValue(settings());
+    OpenAIProvider.mockImplementation(function () {
+      return { generate };
+    });
+
+    const { generateJSON } = await freshClient();
+    await generateJSON([], { temperature: 0.4 });
+
+    expect(generate).toHaveBeenCalledWith([], expect.objectContaining({ temperature: 0.4 }));
+  });
+
+  it("throws with a snippet of the response when there is no JSON at all", async () => {
+    respondWith("I cannot help with that request.");
+    const { generateJSON } = await freshClient();
+    await expect(generateJSON([])).rejects.toThrow(/did not return valid JSON/);
+    await expect(generateJSON([])).rejects.toThrow(/I cannot help with that request/);
+  });
+
+  it("throws when the extracted text is not parseable JSON", async () => {
+    respondWith("{not json at all}");
+    const { generateJSON } = await freshClient();
+    await expect(generateJSON([])).rejects.toThrow();
+  });
+});

--- a/tests/lib/llm/providers/anthropic.test.ts
+++ b/tests/lib/llm/providers/anthropic.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { create, stream, ctor } = vi.hoisted(() => ({
+  create: vi.fn(),
+  stream: vi.fn(),
+  ctor: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: function (options: { apiKey?: string }) {
+    ctor(options);
+    return { messages: { create, stream } };
+  },
+}));
+
+import { AnthropicProvider } from "@/lib/llm/providers/anthropic";
+
+const reply = (text: string) => ({
+  content: [{ type: "text", text }],
+  usage: { input_tokens: 12, output_tokens: 5 },
+});
+
+const args = (call = 0) => create.mock.calls[call][0];
+
+beforeEach(() => {
+  create.mockResolvedValue(reply("hello"));
+});
+
+describe("AnthropicProvider", () => {
+  it("passes the API key to the SDK", () => {
+    new AnthropicProvider("sk-ant");
+    expect(ctor).toHaveBeenCalledWith({ apiKey: "sk-ant" });
+  });
+
+  it("falls back to ANTHROPIC_API_KEY", () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-env");
+    new AnthropicProvider();
+    expect(ctor).toHaveBeenCalledWith({ apiKey: "sk-env" });
+  });
+
+  it("defaults to a Claude Sonnet model", async () => {
+    await new AnthropicProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(args().model).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("prefers ANTHROPIC_MODEL, then an explicit model", async () => {
+    vi.stubEnv("ANTHROPIC_MODEL", "claude-haiku");
+    await new AnthropicProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(args(0).model).toBe("claude-haiku");
+
+    await new AnthropicProvider("sk", "claude-opus").generate([{ role: "user", content: "hi" }]);
+    expect(args(1).model).toBe("claude-opus");
+  });
+
+  it("lifts the system message out of the message list", async () => {
+    await new AnthropicProvider("sk").generate([
+      { role: "system", content: "Be terse." },
+      { role: "user", content: "hi" },
+    ]);
+
+    expect(args().system).toBe("Be terse.");
+    expect(args().messages).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  it("omits the system field when there is no system message", async () => {
+    await new AnthropicProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(args()).not.toHaveProperty("system");
+  });
+
+  it("returns the text of the first content block", async () => {
+    const result = await new AnthropicProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(result.content).toBe("hello");
+  });
+
+  it("returns an empty string for a non-text content block", async () => {
+    create.mockResolvedValue({
+      content: [{ type: "tool_use" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    const result = await new AnthropicProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(result.content).toBe("");
+  });
+
+  it("maps token usage", async () => {
+    const result = await new AnthropicProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(result.usage).toEqual({ promptTokens: 12, completionTokens: 5 });
+  });
+
+  describe("JSON mode", () => {
+    it("adds a JSON instruction to the system prompt", async () => {
+      await new AnthropicProvider("sk").generate(
+        [{ role: "system", content: "Be terse." }, { role: "user", content: "hi" }],
+        { json: true }
+      );
+
+      expect(args().system).toContain("Be terse.");
+      expect(args().system).toContain("Respond with valid JSON only");
+    });
+
+    it("works with no system message of its own", async () => {
+      await new AnthropicProvider("sk").generate([{ role: "user", content: "hi" }], { json: true });
+      expect(args().system).toBe("Respond with valid JSON only. No explanation, no markdown.");
+    });
+
+    it("pre-fills the assistant turn with an opening brace", async () => {
+      await new AnthropicProvider("sk").generate([{ role: "user", content: "hi" }], { json: true });
+      expect(args().messages).toEqual([
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "{" },
+      ]);
+    });
+
+    it("re-attaches the prefilled brace so the result parses", async () => {
+      create.mockResolvedValue(reply('"ok":true}'));
+
+      const result = await new AnthropicProvider("sk").generate(
+        [{ role: "user", content: "hi" }],
+        { json: true }
+      );
+
+      expect(result.content).toBe('{"ok":true}');
+      expect(JSON.parse(result.content)).toEqual({ ok: true });
+    });
+
+    it("does not prefill when JSON mode is off", async () => {
+      await new AnthropicProvider("sk").generate([{ role: "user", content: "hi" }]);
+      expect(args().messages).toEqual([{ role: "user", content: "hi" }]);
+    });
+  });
+
+  it("yields text deltas and a final done chunk when streaming", async () => {
+    stream.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "content_block_delta", delta: { type: "text_delta", text: "Hel" } };
+        yield { type: "message_start" };
+        yield { type: "content_block_delta", delta: { type: "text_delta", text: "lo" } };
+      },
+    });
+
+    const chunks = [];
+    for await (const chunk of new AnthropicProvider("sk").stream([{ role: "user", content: "hi" }])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([
+      { content: "Hel", done: false },
+      { content: "lo", done: false },
+      { content: "", done: true },
+    ]);
+  });
+});

--- a/tests/lib/llm/providers/gemini.test.ts
+++ b/tests/lib/llm/providers/gemini.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getGenerativeModel, startChat, sendMessage, sendMessageStream, ctor } = vi.hoisted(() => ({
+  getGenerativeModel: vi.fn(),
+  startChat: vi.fn(),
+  sendMessage: vi.fn(),
+  sendMessageStream: vi.fn(),
+  ctor: vi.fn(),
+}));
+
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: function (apiKey: string) {
+    ctor(apiKey);
+    return { getGenerativeModel };
+  },
+}));
+
+import { GeminiProvider } from "@/lib/llm/providers/gemini";
+
+beforeEach(() => {
+  sendMessage.mockResolvedValue({
+    response: {
+      text: () => "hello",
+      usageMetadata: { promptTokenCount: 9, candidatesTokenCount: 3 },
+    },
+  });
+  startChat.mockReturnValue({ sendMessage, sendMessageStream });
+  getGenerativeModel.mockReturnValue({ startChat });
+});
+
+const modelArgs = (call = 0) => getGenerativeModel.mock.calls[call][0];
+const chatArgs = (call = 0) => startChat.mock.calls[call][0];
+
+describe("GeminiProvider", () => {
+  it("passes the API key to the SDK", () => {
+    new GeminiProvider("goog-key");
+    expect(ctor).toHaveBeenCalledWith("goog-key");
+  });
+
+  it("falls back to GOOGLE_API_KEY, then an empty string", () => {
+    vi.stubEnv("GOOGLE_API_KEY", "goog-env");
+    new GeminiProvider();
+    expect(ctor).toHaveBeenCalledWith("goog-env");
+
+    vi.unstubAllEnvs();
+    new GeminiProvider();
+    expect(ctor).toHaveBeenLastCalledWith("");
+  });
+
+  it("defaults the model, and prefers GEMINI_MODEL then an explicit one", async () => {
+    await new GeminiProvider("k").generate([{ role: "user", content: "hi" }]);
+    expect(modelArgs(0).model).toBe("gemini-2.0-flash");
+
+    vi.stubEnv("GEMINI_MODEL", "gemini-1.5-pro");
+    await new GeminiProvider("k").generate([{ role: "user", content: "hi" }]);
+    expect(modelArgs(1).model).toBe("gemini-1.5-pro");
+
+    await new GeminiProvider("k", "gemini-3").generate([{ role: "user", content: "hi" }]);
+    expect(modelArgs(2).model).toBe("gemini-3");
+  });
+
+  it("applies default generation settings", async () => {
+    await new GeminiProvider("k").generate([{ role: "user", content: "hi" }]);
+    expect(modelArgs().generationConfig).toMatchObject({
+      temperature: 0.7,
+      maxOutputTokens: 4096,
+    });
+  });
+
+  it("requests a JSON mime type only in JSON mode", async () => {
+    await new GeminiProvider("k").generate([{ role: "user", content: "hi" }]);
+    expect(modelArgs(0).generationConfig).not.toHaveProperty("responseMimeType");
+
+    await new GeminiProvider("k").generate([{ role: "user", content: "hi" }], { json: true });
+    expect(modelArgs(1).generationConfig.responseMimeType).toBe("application/json");
+  });
+
+  it("passes the system message as a system instruction", async () => {
+    await new GeminiProvider("k").generate([
+      { role: "system", content: "Be terse." },
+      { role: "user", content: "hi" },
+    ]);
+
+    expect(chatArgs().systemInstruction).toEqual({
+      role: "user",
+      parts: [{ text: "Be terse." }],
+    });
+  });
+
+  it("sends only the last message, keeping the rest as history", async () => {
+    await new GeminiProvider("k").generate([
+      { role: "user", content: "first" },
+      { role: "assistant", content: "reply" },
+      { role: "user", content: "second" },
+    ]);
+
+    expect(chatArgs().history).toEqual([
+      { role: "user", parts: [{ text: "first" }] },
+      { role: "model", parts: [{ text: "reply" }] },
+    ]);
+    expect(sendMessage).toHaveBeenCalledWith("second");
+  });
+
+  it("returns the response text and usage", async () => {
+    const result = await new GeminiProvider("k").generate([{ role: "user", content: "hi" }]);
+    expect(result.content).toBe("hello");
+    expect(result.usage).toEqual({ promptTokens: 9, completionTokens: 3 });
+  });
+
+  it("omits usage when the API reports none", async () => {
+    sendMessage.mockResolvedValue({ response: { text: () => "hello" } });
+    const result = await new GeminiProvider("k").generate([{ role: "user", content: "hi" }]);
+    expect(result.usage).toBeUndefined();
+  });
+
+  it("streams non-empty chunks and ends with a done marker", async () => {
+    sendMessageStream.mockResolvedValue({
+      stream: {
+        async *[Symbol.asyncIterator]() {
+          yield { text: () => "Hel" };
+          yield { text: () => "" };
+          yield { text: () => "lo" };
+        },
+      },
+    });
+
+    const chunks = [];
+    for await (const chunk of new GeminiProvider("k").stream([{ role: "user", content: "hi" }])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([
+      { content: "Hel", done: false },
+      { content: "lo", done: false },
+      { content: "", done: true },
+    ]);
+  });
+});

--- a/tests/lib/llm/providers/ollama.test.ts
+++ b/tests/lib/llm/providers/ollama.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OllamaProvider } from "@/lib/llm/providers/ollama";
+
+const fetchMock = vi.fn();
+
+const jsonResponse = (body: unknown) => ({ json: async () => body });
+
+const streamResponse = (lines: string[]) => {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return {
+    body: {
+      getReader: () => ({
+        read: async () =>
+          i < lines.length
+            ? { done: false, value: encoder.encode(lines[i++]) }
+            : { done: true, value: undefined },
+      }),
+    },
+  };
+};
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockResolvedValue(jsonResponse({ message: { content: "hello" } }));
+});
+
+const bodyOf = (call = 0) => JSON.parse(fetchMock.mock.calls[call][1].body);
+
+describe("OllamaProvider", () => {
+  it("defaults to the local ollama server and llama3.1", async () => {
+    await new OllamaProvider().generate([{ role: "user", content: "hi" }]);
+
+    expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:11434/api/chat");
+    expect(bodyOf().model).toBe("llama3.1");
+  });
+
+  it("uses OLLAMA_BASE_URL and OLLAMA_MODEL when set", async () => {
+    vi.stubEnv("OLLAMA_BASE_URL", "http://ollama:11434");
+    vi.stubEnv("OLLAMA_MODEL", "mistral");
+
+    await new OllamaProvider().generate([{ role: "user", content: "hi" }]);
+
+    expect(fetchMock.mock.calls[0][0]).toBe("http://ollama:11434/api/chat");
+    expect(bodyOf().model).toBe("mistral");
+  });
+
+  it("prefers explicit constructor arguments", async () => {
+    vi.stubEnv("OLLAMA_BASE_URL", "http://env:11434");
+    await new OllamaProvider("http://explicit:11434", "phi").generate([
+      { role: "user", content: "hi" },
+    ]);
+
+    expect(fetchMock.mock.calls[0][0]).toBe("http://explicit:11434/api/chat");
+    expect(bodyOf().model).toBe("phi");
+  });
+
+  it("returns the message content", async () => {
+    const result = await new OllamaProvider().generate([{ role: "user", content: "hi" }]);
+    expect(result.content).toBe("hello");
+  });
+
+  it("returns an empty string when ollama sends no message", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}));
+    const result = await new OllamaProvider().generate([{ role: "user", content: "hi" }]);
+    expect(result.content).toBe("");
+  });
+
+  it("maps eval counts to token usage", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ message: { content: "hi" }, eval_count: 7, prompt_eval_count: 3 })
+    );
+    const result = await new OllamaProvider().generate([{ role: "user", content: "hi" }]);
+    expect(result.usage).toEqual({ promptTokens: 3, completionTokens: 7 });
+  });
+
+  it("omits usage when ollama reports no eval count", async () => {
+    const result = await new OllamaProvider().generate([{ role: "user", content: "hi" }]);
+    expect(result.usage).toBeUndefined();
+  });
+
+  it("does not stream for a plain generate call", async () => {
+    await new OllamaProvider().generate([{ role: "user", content: "hi" }]);
+    expect(bodyOf().stream).toBe(false);
+  });
+
+  it("maps options onto ollama's option names", async () => {
+    await new OllamaProvider().generate([{ role: "user", content: "hi" }], {
+      temperature: 0.2,
+      maxTokens: 256,
+    });
+    expect(bodyOf().options).toEqual({ temperature: 0.2, num_predict: 256 });
+  });
+
+  it("asks for JSON format only when requested", async () => {
+    await new OllamaProvider().generate([{ role: "user", content: "hi" }]);
+    expect(bodyOf(0).format).toBeUndefined();
+
+    await new OllamaProvider().generate([{ role: "user", content: "hi" }], { json: true });
+    expect(bodyOf(1).format).toBe("json");
+  });
+
+  it("yields each streamed line", async () => {
+    fetchMock.mockResolvedValue(
+      streamResponse([
+        '{"message":{"content":"Hel"},"done":false}\n',
+        '{"message":{"content":"lo"},"done":true}\n',
+      ])
+    );
+
+    const chunks = [];
+    for await (const chunk of new OllamaProvider().stream([{ role: "user", content: "hi" }])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([
+      { content: "Hel", done: false },
+      { content: "lo", done: true },
+    ]);
+  });
+
+  it("reassembles a JSON object split across two reads", async () => {
+    fetchMock.mockResolvedValue(
+      streamResponse(['{"message":{"content":"Hel', 'lo"},"done":true}\n'])
+    );
+
+    const chunks = [];
+    for await (const chunk of new OllamaProvider().stream([{ role: "user", content: "hi" }])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([{ content: "Hello", done: true }]);
+  });
+
+  it("throws when the response has no body to read", async () => {
+    fetchMock.mockResolvedValue({ body: null });
+
+    const iterator = new OllamaProvider().stream([{ role: "user", content: "hi" }]);
+    await expect(iterator.next()).rejects.toThrow("No response body");
+  });
+});

--- a/tests/lib/llm/providers/openai.test.ts
+++ b/tests/lib/llm/providers/openai.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { create, ctor } = vi.hoisted(() => ({ create: vi.fn(), ctor: vi.fn() }));
+
+vi.mock("openai", () => ({
+  default: function (options: { apiKey?: string }) {
+    ctor(options);
+    return { chat: { completions: { create } } };
+  },
+}));
+
+import { OpenAIProvider } from "@/lib/llm/providers/openai";
+
+const completion = (content: string | null, usage?: object) => ({
+  choices: [{ message: { content }, finish_reason: "stop" }],
+  usage,
+});
+
+beforeEach(() => {
+  create.mockResolvedValue(completion("hello"));
+});
+
+describe("OpenAIProvider", () => {
+  it("passes the API key to the SDK", () => {
+    new OpenAIProvider("sk-explicit");
+    expect(ctor).toHaveBeenCalledWith({ apiKey: "sk-explicit" });
+  });
+
+  it("falls back to OPENAI_API_KEY", () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-env");
+    new OpenAIProvider();
+    expect(ctor).toHaveBeenCalledWith({ apiKey: "sk-env" });
+  });
+
+  it("defaults the model to gpt-4o", async () => {
+    await new OpenAIProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ model: "gpt-4o" }));
+  });
+
+  it("prefers OPENAI_MODEL over the default", async () => {
+    vi.stubEnv("OPENAI_MODEL", "gpt-4o-mini");
+    await new OpenAIProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ model: "gpt-4o-mini" }));
+  });
+
+  it("prefers an explicit model over the environment", async () => {
+    vi.stubEnv("OPENAI_MODEL", "gpt-4o-mini");
+    await new OpenAIProvider("sk", "gpt-5").generate([{ role: "user", content: "hi" }]);
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ model: "gpt-5" }));
+  });
+
+  it("returns the message content", async () => {
+    await expect(
+      new OpenAIProvider("sk").generate([{ role: "user", content: "hi" }])
+    ).resolves.toMatchObject({ content: "hello" });
+  });
+
+  it("returns an empty string when the model returns no content", async () => {
+    create.mockResolvedValue(completion(null));
+    const result = await new OpenAIProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(result.content).toBe("");
+  });
+
+  it("maps token usage when the API reports it", async () => {
+    create.mockResolvedValue(completion("hi", { prompt_tokens: 10, completion_tokens: 4 }));
+    const result = await new OpenAIProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(result.usage).toEqual({ promptTokens: 10, completionTokens: 4 });
+  });
+
+  it("omits usage when the API does not report it", async () => {
+    const result = await new OpenAIProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(result.usage).toBeUndefined();
+  });
+
+  it("applies default temperature and token limits", async () => {
+    await new OpenAIProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ temperature: 0.7, max_tokens: 4096 })
+    );
+  });
+
+  it("honours explicit options", async () => {
+    await new OpenAIProvider("sk").generate([{ role: "user", content: "hi" }], {
+      temperature: 0.1,
+      maxTokens: 100,
+    });
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ temperature: 0.1, max_tokens: 100 })
+    );
+  });
+
+  it("requests JSON mode only when asked", async () => {
+    await new OpenAIProvider("sk").generate([{ role: "user", content: "hi" }]);
+    expect(create.mock.calls[0][0]).not.toHaveProperty("response_format");
+
+    await new OpenAIProvider("sk").generate([{ role: "user", content: "hi" }], { json: true });
+    expect(create.mock.calls[1][0]).toMatchObject({
+      response_format: { type: "json_object" },
+    });
+  });
+
+  it("streams the deltas the API sends, skipping empty ones", async () => {
+    create.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        yield { choices: [{ delta: { content: "Hel" }, finish_reason: null }] };
+        yield { choices: [{ delta: { content: "" }, finish_reason: null }] };
+        yield { choices: [{ delta: { content: "lo" }, finish_reason: "stop" }] };
+      },
+    });
+
+    const chunks = [];
+    for await (const chunk of new OpenAIProvider("sk").stream([{ role: "user", content: "hi" }])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([
+      { content: "Hel", done: false },
+      { content: "lo", done: true },
+    ]);
+  });
+
+  it("asks for a stream when streaming", async () => {
+    create.mockResolvedValue({ async *[Symbol.asyncIterator]() {} });
+    const iterator = new OpenAIProvider("sk").stream([{ role: "user", content: "hi" }]);
+    await iterator.next();
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ stream: true }));
+  });
+});

--- a/tests/lib/settings/resolve.test.ts
+++ b/tests/lib/settings/resolve.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const findUnique = vi.fn();
+const getSession = vi.fn();
+
+vi.mock("@/lib/db", () => ({ prisma: { user: { findUnique } } }));
+vi.mock("@/lib/auth/session", () => ({ getSession }));
+
+const { resolveSettings } = await import("@/lib/settings/resolve");
+
+const signedIn = (settings: unknown) => {
+  getSession.mockResolvedValue({ user: { id: "user_1" } });
+  findUnique.mockResolvedValue({ settings });
+};
+
+describe("resolveSettings", () => {
+  beforeEach(() => {
+    getSession.mockResolvedValue(null);
+    findUnique.mockResolvedValue(null);
+  });
+
+  describe("with no user settings and no environment", () => {
+    it("falls back to documented defaults", async () => {
+      await expect(resolveSettings()).resolves.toEqual({
+        llmProvider: "openai",
+        llmApiKey: "",
+        llmModel: "gpt-4o",
+        ollamaUrl: "http://localhost:11434",
+        imageProvider: "openai",
+        imageApiKey: "",
+        videoProvider: "veo",
+        videoApiKey: "",
+      });
+    });
+  });
+
+  describe("environment variables", () => {
+    it("selects the provider from LLM_PROVIDER", async () => {
+      vi.stubEnv("LLM_PROVIDER", "anthropic");
+      vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-env");
+
+      const settings = await resolveSettings();
+      expect(settings.llmProvider).toBe("anthropic");
+      expect(settings.llmApiKey).toBe("sk-ant-env");
+      expect(settings.llmModel).toBe("claude-sonnet-4-20250514");
+    });
+
+    it("picks the API key matching the selected LLM provider", async () => {
+      vi.stubEnv("OPENAI_API_KEY", "sk-openai");
+      vi.stubEnv("GOOGLE_API_KEY", "goog");
+      vi.stubEnv("LLM_PROVIDER", "gemini");
+
+      expect((await resolveSettings()).llmApiKey).toBe("goog");
+    });
+
+    it("leaves the key empty for ollama, which needs none", async () => {
+      vi.stubEnv("LLM_PROVIDER", "ollama");
+      vi.stubEnv("OPENAI_API_KEY", "sk-openai");
+
+      const settings = await resolveSettings();
+      expect(settings.llmApiKey).toBe("");
+      expect(settings.llmModel).toBe("llama3.1");
+    });
+
+    it("honours per-provider model overrides", async () => {
+      vi.stubEnv("OPENAI_MODEL", "gpt-4o-mini");
+      expect((await resolveSettings()).llmModel).toBe("gpt-4o-mini");
+    });
+
+    it("resolves the image provider key independently of the LLM one", async () => {
+      vi.stubEnv("IMAGE_PROVIDER", "replicate");
+      vi.stubEnv("REPLICATE_API_TOKEN", "r8_token");
+      vi.stubEnv("OPENAI_API_KEY", "sk-openai");
+
+      const settings = await resolveSettings();
+      expect(settings.imageProvider).toBe("replicate");
+      expect(settings.imageApiKey).toBe("r8_token");
+      expect(settings.llmApiKey).toBe("sk-openai");
+    });
+
+    it("maps each image provider to its own key", async () => {
+      vi.stubEnv("STABILITY_API_KEY", "sk-stability");
+      vi.stubEnv("IMAGE_PROVIDER", "stability");
+      expect((await resolveSettings()).imageApiKey).toBe("sk-stability");
+    });
+
+    it("maps each video provider to its own key", async () => {
+      vi.stubEnv("HEYGEN_API_KEY", "hg");
+      vi.stubEnv("DID_API_KEY", "did");
+      vi.stubEnv("GOOGLE_API_KEY", "goog");
+
+      vi.stubEnv("VIDEO_PROVIDER", "heygen");
+      expect((await resolveSettings()).videoApiKey).toBe("hg");
+
+      vi.stubEnv("VIDEO_PROVIDER", "did");
+      expect((await resolveSettings()).videoApiKey).toBe("did");
+
+      vi.stubEnv("VIDEO_PROVIDER", "veo");
+      expect((await resolveSettings()).videoApiKey).toBe("goog");
+    });
+
+    it("uses OLLAMA_BASE_URL when set", async () => {
+      vi.stubEnv("OLLAMA_BASE_URL", "http://ollama:11434");
+      expect((await resolveSettings()).ollamaUrl).toBe("http://ollama:11434");
+    });
+  });
+
+  describe("user settings take priority over the environment", () => {
+    it("overrides provider, key and model", async () => {
+      vi.stubEnv("LLM_PROVIDER", "openai");
+      vi.stubEnv("OPENAI_API_KEY", "sk-from-env");
+      signedIn({ llmProvider: "anthropic", llmApiKey: "sk-from-db", llmModel: "claude-opus-4" });
+
+      const settings = await resolveSettings();
+      expect(settings.llmProvider).toBe("anthropic");
+      expect(settings.llmApiKey).toBe("sk-from-db");
+      expect(settings.llmModel).toBe("claude-opus-4");
+    });
+
+    it("falls back to the environment for fields the user has not set", async () => {
+      vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-env");
+      signedIn({ llmProvider: "anthropic" });
+
+      const settings = await resolveSettings();
+      expect(settings.llmApiKey).toBe("sk-ant-env");
+      expect(settings.llmModel).toBe("claude-sonnet-4-20250514");
+    });
+
+    it("looks the settings up for the signed-in user", async () => {
+      signedIn({ llmProvider: "ollama" });
+      await resolveSettings();
+
+      expect(findUnique).toHaveBeenCalledWith({
+        where: { id: "user_1" },
+        select: { settings: true },
+      });
+    });
+
+    it("ignores a null settings column", async () => {
+      vi.stubEnv("OPENAI_API_KEY", "sk-openai");
+      signedIn(null);
+
+      expect((await resolveSettings()).llmApiKey).toBe("sk-openai");
+    });
+  });
+
+  describe("when the session or database is unavailable", () => {
+    it("does not query the database for an anonymous request", async () => {
+      getSession.mockResolvedValue(null);
+      await resolveSettings();
+      expect(findUnique).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the environment when the session lookup throws", async () => {
+      vi.stubEnv("OPENAI_API_KEY", "sk-openai");
+      getSession.mockRejectedValue(new Error("no request context"));
+
+      expect((await resolveSettings()).llmApiKey).toBe("sk-openai");
+    });
+
+    it("falls back to the environment when the database is down", async () => {
+      vi.stubEnv("OPENAI_API_KEY", "sk-openai");
+      getSession.mockResolvedValue({ user: { id: "user_1" } });
+      findUnique.mockRejectedValue(new Error("connection refused"));
+
+      expect((await resolveSettings()).llmApiKey).toBe("sk-openai");
+    });
+  });
+});

--- a/tests/lib/social/publishers.test.ts
+++ b/tests/lib/social/publishers.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { publishToTwitter } from "@/lib/social/twitter";
+import { publishToLinkedIn } from "@/lib/social/linkedin";
+import { publishToFacebook, publishToInstagram } from "@/lib/social/meta";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockResolvedValue({ json: async () => ({ id: "post_1" }) });
+});
+
+const call = (n = 0) => ({
+  url: fetchMock.mock.calls[n][0] as string,
+  init: fetchMock.mock.calls[n][1] as { method: string; headers: Record<string, string>; body: string },
+});
+const bodyOf = (n = 0) => JSON.parse(call(n).init.body);
+
+describe("publishToTwitter", () => {
+  const options = {
+    apiKey: "consumer-key",
+    apiSecret: "consumer-secret",
+    accessToken: "access-token",
+    accessTokenSecret: "access-secret",
+    text: "Hello world",
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-25T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("posts the text to the v2 tweets endpoint", async () => {
+    await publishToTwitter(options);
+
+    expect(call().url).toBe("https://api.twitter.com/2/tweets");
+    expect(call().init.method).toBe("POST");
+    expect(bodyOf()).toEqual({ text: "Hello world" });
+  });
+
+  it("attaches media when a media id is supplied", async () => {
+    await publishToTwitter({ ...options, mediaId: "media_9" });
+    expect(bodyOf()).toEqual({ text: "Hello world", media: { media_ids: ["media_9"] } });
+  });
+
+  it("signs the request with OAuth 1.0a", async () => {
+    await publishToTwitter(options);
+
+    const auth = call().init.headers.Authorization;
+    expect(auth).toMatch(/^OAuth /);
+    expect(auth).toContain('oauth_consumer_key="consumer-key"');
+    expect(auth).toContain('oauth_token="access-token"');
+    expect(auth).toContain('oauth_signature_method="HMAC-SHA1"');
+    expect(auth).toContain('oauth_version="1.0"');
+    expect(auth).toContain("oauth_signature=");
+  });
+
+  it("stamps the request with the current unix time", async () => {
+    await publishToTwitter(options);
+    expect(call().init.headers.Authorization).toContain(
+      `oauth_timestamp="${Math.floor(Date.parse("2026-08-25T12:00:00Z") / 1000)}"`
+    );
+  });
+
+  it("uses a different nonce on every call", async () => {
+    await publishToTwitter(options);
+    await publishToTwitter(options);
+
+    const nonce = (n: number) =>
+      /oauth_nonce="([^"]+)"/.exec(call(n).init.headers.Authorization)![1];
+
+    expect(nonce(0)).not.toBe(nonce(1));
+  });
+
+  it("never puts the secrets in the header in the clear", async () => {
+    await publishToTwitter(options);
+
+    const auth = call().init.headers.Authorization;
+    expect(auth).not.toContain("consumer-secret");
+    expect(auth).not.toContain("access-secret");
+  });
+
+  it("returns the parsed API response", async () => {
+    await expect(publishToTwitter(options)).resolves.toEqual({ id: "post_1" });
+  });
+});
+
+describe("publishToLinkedIn", () => {
+  const options = { accessToken: "li-token", personUrn: "urn:li:person:1", text: "Hello" };
+
+  it("posts a text share to the ugcPosts endpoint", async () => {
+    await publishToLinkedIn(options);
+
+    expect(call().url).toBe("https://api.linkedin.com/v2/ugcPosts");
+    expect(call().init.headers.Authorization).toBe("Bearer li-token");
+    expect(call().init.headers["X-Restli-Protocol-Version"]).toBe("2.0.0");
+  });
+
+  it("marks a text-only post as having no media", async () => {
+    await publishToLinkedIn(options);
+
+    const content = bodyOf().specificContent["com.linkedin.ugc.ShareContent"];
+    expect(content.shareMediaCategory).toBe("NONE");
+    expect(content).not.toHaveProperty("media");
+    expect(content.shareCommentary).toEqual({ text: "Hello" });
+  });
+
+  it("attaches an image when one is supplied", async () => {
+    await publishToLinkedIn({ ...options, imageUrl: "https://cdn/i.png" });
+
+    const content = bodyOf().specificContent["com.linkedin.ugc.ShareContent"];
+    expect(content.shareMediaCategory).toBe("IMAGE");
+    expect(content.media).toEqual([{ status: "READY", originalUrl: "https://cdn/i.png" }]);
+  });
+
+  it("posts publicly as the given author", async () => {
+    await publishToLinkedIn(options);
+
+    expect(bodyOf().author).toBe("urn:li:person:1");
+    expect(bodyOf().lifecycleState).toBe("PUBLISHED");
+    expect(bodyOf().visibility["com.linkedin.ugc.MemberNetworkVisibility"]).toBe("PUBLIC");
+  });
+});
+
+describe("publishToFacebook", () => {
+  const options = {
+    accessToken: "fb-token",
+    pageId: "page_1",
+    message: "Hello",
+    platform: "facebook" as const,
+  };
+
+  it("posts text to the page feed", async () => {
+    await publishToFacebook(options);
+
+    expect(call().url).toBe("https://graph.facebook.com/v19.0/page_1/feed");
+    expect(bodyOf()).toEqual({ message: "Hello", access_token: "fb-token" });
+  });
+
+  it("posts to the photos endpoint when there is an image", async () => {
+    await publishToFacebook({ ...options, imageUrl: "https://cdn/i.png" });
+
+    expect(call().url).toBe("https://graph.facebook.com/v19.0/page_1/photos");
+    expect(bodyOf()).toEqual({
+      url: "https://cdn/i.png",
+      message: "Hello",
+      access_token: "fb-token",
+    });
+  });
+
+  it("returns the parsed API response", async () => {
+    await expect(publishToFacebook(options)).resolves.toEqual({ id: "post_1" });
+  });
+});
+
+describe("publishToInstagram", () => {
+  const options = {
+    accessToken: "ig-token",
+    pageId: "ig_1",
+    message: "Hello",
+    imageUrl: "https://cdn/i.png",
+    platform: "instagram" as const,
+  };
+
+  it("refuses to post without an image", async () => {
+    await expect(publishToInstagram({ ...options, imageUrl: undefined })).rejects.toThrow(
+      "Instagram requires an image"
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("creates a media container then publishes it", async () => {
+    fetchMock
+      .mockResolvedValueOnce({ json: async () => ({ id: "container_1" }) })
+      .mockResolvedValueOnce({ json: async () => ({ id: "published_1" }) });
+
+    const result = await publishToInstagram(options);
+
+    expect(call(0).url).toBe("https://graph.facebook.com/v19.0/ig_1/media");
+    expect(bodyOf(0)).toEqual({
+      image_url: "https://cdn/i.png",
+      caption: "Hello",
+      access_token: "ig-token",
+    });
+
+    expect(call(1).url).toBe("https://graph.facebook.com/v19.0/ig_1/media_publish");
+    expect(bodyOf(1)).toEqual({ creation_id: "container_1", access_token: "ig-token" });
+
+    expect(result).toEqual({ id: "published_1" });
+  });
+});

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "@/lib/utils";
+
+describe("cn", () => {
+  it("joins class names", () => {
+    expect(cn("px-2", "py-1")).toBe("px-2 py-1");
+  });
+
+  it("drops falsy values", () => {
+    expect(cn("px-2", false, undefined, null, "py-1")).toBe("px-2 py-1");
+  });
+
+  it("applies conditional objects and arrays", () => {
+    expect(cn({ "text-red-500": true, "text-blue-500": false }, ["font-bold"])).toBe(
+      "text-red-500 font-bold"
+    );
+  });
+
+  it("lets a later tailwind class win over an earlier conflicting one", () => {
+    expect(cn("px-2", "px-4")).toBe("px-4");
+    expect(cn("text-red-500", "text-blue-500")).toBe("text-blue-500");
+  });
+
+  it("keeps classes that do not conflict", () => {
+    expect(cn("px-2", "py-4")).toBe("px-2 py-4");
+  });
+
+  it("returns an empty string for no input", () => {
+    expect(cn()).toBe("");
+  });
+});

--- a/tests/lib/video/client.test.ts
+++ b/tests/lib/video/client.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveSettings = vi.fn();
+vi.mock("@/lib/settings/resolve", () => ({ resolveSettings }));
+
+const VeoProvider = vi.fn();
+const HeyGenProvider = vi.fn();
+const DIDProvider = vi.fn();
+
+vi.mock("@/lib/video/providers/veo", () => ({ VeoProvider }));
+vi.mock("@/lib/video/providers/heygen", () => ({ HeyGenProvider }));
+vi.mock("@/lib/video/providers/did", () => ({ DIDProvider }));
+
+const settings = (overrides: Record<string, string> = {}) => ({
+  llmProvider: "openai",
+  llmApiKey: "",
+  llmModel: "gpt-4o",
+  ollamaUrl: "http://localhost:11434",
+  imageProvider: "openai",
+  imageApiKey: "",
+  videoProvider: "veo",
+  videoApiKey: "goog-key",
+  ...overrides,
+});
+
+async function freshClient() {
+  vi.resetModules();
+  return import("@/lib/video/client");
+}
+
+describe("getVideoProvider", () => {
+  beforeEach(() => {
+    // Block body on purpose: an arrow returning the mock would be treated by
+    // Vitest as a teardown callback and invoked after the test.
+    resolveSettings.mockResolvedValue(settings());
+  });
+
+  it.each([
+    ["veo", () => VeoProvider],
+    ["heygen", () => HeyGenProvider],
+    ["did", () => DIDProvider],
+  ])("builds the %s provider with the resolved key", async (provider, ctor) => {
+    resolveSettings.mockResolvedValue(settings({ videoProvider: provider, videoApiKey: "key" }));
+    const { getVideoProvider } = await freshClient();
+    await getVideoProvider();
+    expect(ctor()).toHaveBeenCalledWith("key");
+  });
+
+  it("rejects an unknown provider by name", async () => {
+    resolveSettings.mockResolvedValue(settings({ videoProvider: "sora" }));
+    const { getVideoProvider } = await freshClient();
+    await expect(getVideoProvider()).rejects.toThrow("Unknown video provider: sora");
+  });
+
+  it("reuses the provider when nothing has changed", async () => {
+    const { getVideoProvider } = await freshClient();
+    await getVideoProvider();
+    await getVideoProvider();
+    expect(VeoProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to VIDEO_PROVIDER and the first key it finds", async () => {
+    resolveSettings.mockRejectedValue(new Error("no session"));
+    vi.stubEnv("VIDEO_PROVIDER", "heygen");
+    vi.stubEnv("HEYGEN_API_KEY", "hg-env");
+
+    const { getVideoProvider } = await freshClient();
+    await getVideoProvider();
+    expect(HeyGenProvider).toHaveBeenCalledWith("hg-env");
+  });
+
+  it("prefers GOOGLE_API_KEY over the other provider keys in the fallback path", async () => {
+    resolveSettings.mockRejectedValue(new Error("no session"));
+    vi.stubEnv("GOOGLE_API_KEY", "goog-env");
+    vi.stubEnv("HEYGEN_API_KEY", "hg-env");
+
+    const { getVideoProvider } = await freshClient();
+    await getVideoProvider();
+    expect(VeoProvider).toHaveBeenCalledWith("goog-env");
+  });
+
+  it("defaults to veo when nothing is configured at all", async () => {
+    resolveSettings.mockRejectedValue(new Error("no session"));
+    const { getVideoProvider } = await freshClient();
+    await getVideoProvider();
+    expect(VeoProvider).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/tests/lib/video/providers.test.ts
+++ b/tests/lib/video/providers.test.ts
@@ -1,0 +1,314 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HeyGenProvider } from "@/lib/video/providers/heygen";
+import { DIDProvider } from "@/lib/video/providers/did";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+const ok = (body: unknown) => ({ ok: true, json: async () => body });
+const fail = (status: number, body: unknown = {}) => ({
+  ok: false,
+  status,
+  json: async () => body,
+});
+const call = (n = 0) => ({
+  url: fetchMock.mock.calls[n][0] as string,
+  init: (fetchMock.mock.calls[n][1] ?? {}) as { headers: Record<string, string>; body?: string },
+});
+
+describe("HeyGenProvider", () => {
+  const options = { script: "Try our mug", avatarId: "av_1" };
+
+  it("reads the key from HEYGEN_API_KEY when not given one", async () => {
+    vi.stubEnv("HEYGEN_API_KEY", "hg-env");
+    fetchMock.mockResolvedValue(ok({ data: { avatars: [] } }));
+
+    await new HeyGenProvider().listAvatars();
+
+    expect(call().init.headers["X-Api-Key"]).toBe("hg-env");
+  });
+
+  describe("listAvatars", () => {
+    it("maps HeyGen avatars onto the shared shape", async () => {
+      fetchMock.mockResolvedValue(
+        ok({
+          data: {
+            avatars: [
+              { avatar_id: "a1", avatar_name: "Mia", preview_image_url: "https://t/1.png", gender: "female" },
+            ],
+          },
+        })
+      );
+
+      await expect(new HeyGenProvider("k").listAvatars()).resolves.toEqual([
+        { id: "a1", name: "Mia", thumbnailUrl: "https://t/1.png", gender: "female", style: "professional" },
+      ]);
+    });
+
+    it("defaults an unknown gender to female", async () => {
+      fetchMock.mockResolvedValue(
+        ok({ data: { avatars: [{ avatar_id: "a1", avatar_name: "X", preview_image_url: "", gender: "" }] } })
+      );
+
+      expect((await new HeyGenProvider("k").listAvatars())[0].gender).toBe("female");
+    });
+
+    it("caps the list at 24", async () => {
+      const avatars = Array.from({ length: 40 }, (_, i) => ({
+        avatar_id: `a${i}`, avatar_name: "n", preview_image_url: "", gender: "male",
+      }));
+      fetchMock.mockResolvedValue(ok({ data: { avatars } }));
+
+      expect(await new HeyGenProvider("k").listAvatars()).toHaveLength(24);
+    });
+
+    it("returns an empty list when HeyGen sends no avatars", async () => {
+      fetchMock.mockResolvedValue(ok({}));
+      await expect(new HeyGenProvider("k").listAvatars()).resolves.toEqual([]);
+    });
+
+    it("throws on an API error", async () => {
+      fetchMock.mockResolvedValue(fail(401));
+      await expect(new HeyGenProvider("k").listAvatars()).rejects.toThrow("HeyGen avatars error: 401");
+    });
+  });
+
+  describe("generate", () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValue(ok({ data: { video_id: "v_1" } }));
+    });
+
+    it("queues a video and returns its id", async () => {
+      await expect(new HeyGenProvider("k").generate(options)).resolves.toEqual({
+        videoId: "v_1",
+        status: "queued",
+      });
+      expect(call().url).toBe("https://api.heygen.com/v2/video/generate");
+    });
+
+    it.each([
+      [undefined, { width: 1080, height: 1920 }],
+      ["9:16", { width: 1080, height: 1920 }],
+      ["16:9", { width: 1920, height: 1080 }],
+      ["1:1", { width: 1080, height: 1080 }],
+    ])("maps aspect ratio %s to %o", async (aspectRatio, dimension) => {
+      await new HeyGenProvider("k").generate({
+        ...options,
+        ...(aspectRatio ? { aspectRatio: aspectRatio as "16:9" } : {}),
+      });
+
+      expect(JSON.parse(call().init.body!).dimension).toEqual(dimension);
+    });
+
+    it("sends the script and avatar", async () => {
+      await new HeyGenProvider("k").generate(options);
+
+      const input = JSON.parse(call().init.body!).video_inputs[0];
+      expect(input.character.avatar_id).toBe("av_1");
+      expect(input.voice.input_text).toBe("Try our mug");
+    });
+
+    it("uses a white background by default and the product image when given", async () => {
+      await new HeyGenProvider("k").generate(options);
+      expect(JSON.parse(call(0).init.body!).video_inputs[0].background).toEqual({
+        type: "color",
+        value: "#FFFFFF",
+      });
+
+      await new HeyGenProvider("k").generate({ ...options, productImageUrl: "https://cdn/p.png" });
+      expect(JSON.parse(call(1).init.body!).video_inputs[0].background).toEqual({
+        type: "image",
+        url: "https://cdn/p.png",
+      });
+    });
+
+    it("surfaces the API's error message", async () => {
+      fetchMock.mockResolvedValue(fail(400, { message: "avatar not found" }));
+      await expect(new HeyGenProvider("k").generate(options)).rejects.toThrow(
+        "HeyGen generation error: avatar not found"
+      );
+    });
+
+    it("falls back to the status code when the error body is unreadable", async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => {
+          throw new Error("not json");
+        },
+      });
+      await expect(new HeyGenProvider("k").generate(options)).rejects.toThrow(
+        "HeyGen generation error: 500"
+      );
+    });
+
+    it("throws when no video id comes back", async () => {
+      fetchMock.mockResolvedValue(ok({ data: {} }));
+      await expect(new HeyGenProvider("k").generate(options)).rejects.toThrow(
+        "HeyGen did not return a video ID"
+      );
+    });
+  });
+
+  describe("getStatus", () => {
+    it.each([
+      ["completed", "completed"],
+      ["failed", "failed"],
+      ["processing", "processing"],
+      ["pending", "queued"],
+    ])("maps HeyGen status %s to %s", async (heygen, expected) => {
+      fetchMock.mockResolvedValue(ok({ data: { status: heygen } }));
+      const result = await new HeyGenProvider("k").getStatus("v_1");
+      expect(result.status).toBe(expected);
+    });
+
+    it("returns the video url, thumbnail and rounded duration", async () => {
+      fetchMock.mockResolvedValue(
+        ok({
+          data: {
+            status: "completed",
+            video_url: "https://cdn/v.mp4",
+            thumbnail_url: "https://cdn/t.png",
+            duration: 12.6,
+          },
+        })
+      );
+
+      await expect(new HeyGenProvider("k").getStatus("v_1")).resolves.toEqual({
+        videoId: "v_1",
+        status: "completed",
+        videoUrl: "https://cdn/v.mp4",
+        thumbnailUrl: "https://cdn/t.png",
+        duration: 13,
+        error: undefined,
+      });
+    });
+
+    it("reports the failure reason, defaulting when none is given", async () => {
+      fetchMock.mockResolvedValue(ok({ data: { status: "failed" } }));
+      expect((await new HeyGenProvider("k").getStatus("v_1")).error).toBe("Generation failed");
+
+      fetchMock.mockResolvedValue(ok({ data: { status: "failed", error: "bad script" } }));
+      expect((await new HeyGenProvider("k").getStatus("v_1")).error).toBe("bad script");
+    });
+
+    it("throws on an API error", async () => {
+      fetchMock.mockResolvedValue(fail(404));
+      await expect(new HeyGenProvider("k").getStatus("v_1")).rejects.toThrow("HeyGen status error: 404");
+    });
+  });
+});
+
+describe("DIDProvider", () => {
+  const options = { script: "Try our mug", avatarId: "presenter_1" };
+
+  it("authenticates with a Basic header from DID_API_KEY", async () => {
+    vi.stubEnv("DID_API_KEY", "did-env");
+    fetchMock.mockResolvedValue(ok({ presenters: [] }));
+
+    await new DIDProvider().listAvatars();
+
+    expect(call().init.headers.Authorization).toBe("Basic did-env");
+  });
+
+  it("maps presenters onto the shared shape and caps at 24", async () => {
+    fetchMock.mockResolvedValue(
+      ok({
+        presenters: Array.from({ length: 30 }, (_, i) => ({
+          presenter_id: `p${i}`, name: "", thumbnail_url: "https://t.png", gender: "male",
+        })),
+      })
+    );
+
+    const avatars = await new DIDProvider("k").listAvatars();
+
+    expect(avatars).toHaveLength(24);
+    expect(avatars[0]).toEqual({
+      id: "p0", name: "Presenter", thumbnailUrl: "https://t.png", gender: "male", style: "professional",
+    });
+  });
+
+  it("throws when presenters cannot be listed", async () => {
+    fetchMock.mockResolvedValue(fail(403));
+    await expect(new DIDProvider("k").listAvatars()).rejects.toThrow("D-ID presenters error: 403");
+  });
+
+  describe("generate", () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValue(ok({ id: "clip_1" }));
+    });
+
+    it("creates a clip and returns its id", async () => {
+      await expect(new DIDProvider("k").generate(options)).resolves.toEqual({
+        videoId: "clip_1",
+        status: "queued",
+      });
+      expect(call().url).toBe("https://api.d-id.com/clips");
+    });
+
+    it("sends the presenter and script", async () => {
+      await new DIDProvider("k").generate(options);
+
+      const body = JSON.parse(call().init.body!);
+      expect(body.presenter_id).toBe("presenter_1");
+      expect(body.script.input).toBe("Try our mug");
+      expect(body.config.result_format).toBe("mp4");
+    });
+
+    it("adds a background only when a product image is supplied", async () => {
+      await new DIDProvider("k").generate(options);
+      expect(JSON.parse(call(0).init.body!)).not.toHaveProperty("background");
+
+      await new DIDProvider("k").generate({ ...options, productImageUrl: "https://cdn/p.png" });
+      expect(JSON.parse(call(1).init.body!).background).toEqual({ source_url: "https://cdn/p.png" });
+    });
+
+    it("surfaces the API's description on error", async () => {
+      fetchMock.mockResolvedValue(fail(400, { description: "invalid presenter" }));
+      await expect(new DIDProvider("k").generate(options)).rejects.toThrow(
+        "D-ID generation error: invalid presenter"
+      );
+    });
+  });
+
+  describe("getStatus", () => {
+    it.each([
+      ["done", "completed"],
+      ["error", "failed"],
+      ["started", "processing"],
+      ["created", "processing"],
+      ["queued", "queued"],
+    ])("maps D-ID status %s to %s", async (did, expected) => {
+      fetchMock.mockResolvedValue(ok({ status: did }));
+      expect((await new DIDProvider("k").getStatus("clip_1")).status).toBe(expected);
+    });
+
+    it("returns the result url and rounded duration", async () => {
+      fetchMock.mockResolvedValue(
+        ok({ status: "done", result_url: "https://cdn/v.mp4", thumbnail_url: "https://cdn/t.png", duration: 9.2 })
+      );
+
+      await expect(new DIDProvider("k").getStatus("clip_1")).resolves.toEqual({
+        videoId: "clip_1",
+        status: "completed",
+        videoUrl: "https://cdn/v.mp4",
+        thumbnailUrl: "https://cdn/t.png",
+        duration: 9,
+        error: undefined,
+      });
+    });
+
+    it("reports a generic failure message", async () => {
+      fetchMock.mockResolvedValue(ok({ status: "error" }));
+      expect((await new DIDProvider("k").getStatus("clip_1")).error).toBe("Video generation failed");
+    });
+
+    it("throws on an API error", async () => {
+      fetchMock.mockResolvedValue(fail(500));
+      await expect(new DIDProvider("k").getStatus("clip_1")).rejects.toThrow("D-ID status error: 500");
+    });
+  });
+});

--- a/tests/lib/video/veo.test.ts
+++ b/tests/lib/video/veo.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: { uGCCharacter: { findMany: vi.fn(), findUnique: vi.fn() } },
+}));
+
+import { prisma } from "@/lib/db";
+import { VeoProvider } from "@/lib/video/providers/veo";
+
+const character = vi.mocked(prisma.uGCCharacter);
+const fetchMock = vi.fn();
+
+const ok = (body: unknown) => ({ ok: true, json: async () => body });
+const call = (n = 0) => ({
+  url: fetchMock.mock.calls[n][0] as string,
+  init: (fetchMock.mock.calls[n][1] ?? {}) as { headers: Record<string, string>; body?: string },
+});
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  character.findMany.mockResolvedValue([] as never);
+  character.findUnique.mockResolvedValue(null as never);
+});
+
+describe("VeoProvider", () => {
+  it("reads the key from GOOGLE_API_KEY when not given one", async () => {
+    vi.stubEnv("GOOGLE_API_KEY", "goog-env");
+    fetchMock.mockResolvedValue(ok({ name: "operations/1" }));
+
+    await new VeoProvider().generate({ script: "s", avatarId: "a" });
+
+    expect(call().init.headers["x-goog-api-key"]).toBe("goog-env");
+  });
+
+  describe("listAvatars", () => {
+    it("maps seeded characters, preferring the preview video as thumbnail", async () => {
+      character.findMany.mockResolvedValue([
+        {
+          id: "c1", name: "Mia", previewVideoUrl: "https://cdn/p.mp4",
+          thumbnailUrl: "https://cdn/t.png", gender: "female", style: "casual",
+        },
+      ] as never);
+
+      await expect(new VeoProvider("k").listAvatars()).resolves.toEqual([
+        { id: "c1", name: "Mia", thumbnailUrl: "https://cdn/p.mp4", gender: "female", style: "casual" },
+      ]);
+      expect(character.findMany).toHaveBeenCalledWith({
+        where: { active: true },
+        orderBy: { sortOrder: "asc" },
+      });
+    });
+
+    it("falls back to the thumbnail, then an empty string", async () => {
+      character.findMany.mockResolvedValue([
+        { id: "c1", name: "A", previewVideoUrl: null, thumbnailUrl: "https://cdn/t.png", gender: "male", style: "s" },
+        { id: "c2", name: "B", previewVideoUrl: null, thumbnailUrl: null, gender: "male", style: "s" },
+      ] as never);
+
+      const avatars = await new VeoProvider("k").listAvatars();
+      expect(avatars[0].thumbnailUrl).toBe("https://cdn/t.png");
+      expect(avatars[1].thumbnailUrl).toBe("");
+    });
+
+    it("returns an empty list when the database is unavailable", async () => {
+      character.findMany.mockRejectedValue(new Error("db down"));
+      await expect(new VeoProvider("k").listAvatars()).resolves.toEqual([]);
+    });
+  });
+
+  describe("generate", () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValue(ok({ name: "operations/abc" }));
+    });
+
+    it("returns the long-running operation name as the video id", async () => {
+      await expect(
+        new VeoProvider("k").generate({ script: "Try our mug", avatarId: "c1" })
+      ).resolves.toEqual({ videoId: "operations/abc", status: "queued" });
+    });
+
+    it.each([
+      [undefined, "9:16"],
+      ["9:16", "9:16"],
+      ["16:9", "16:9"],
+      ["1:1", "16:9"],
+    ])("maps aspect ratio %s to %s", async (requested, expected) => {
+      await new VeoProvider("k").generate({
+        script: "s",
+        avatarId: "c1",
+        ...(requested ? { aspectRatio: requested as "16:9" } : {}),
+      });
+
+      expect(JSON.parse(call().init.body!).parameters.aspectRatio).toBe(expected);
+    });
+
+    it("weaves the character's description into the prompt", async () => {
+      character.findUnique.mockResolvedValue({ description: "a woman in her 30s" } as never);
+
+      await new VeoProvider("k").generate({ script: "Try our mug", avatarId: "c1" });
+
+      const prompt = JSON.parse(call().init.body!).instances[0].prompt;
+      expect(prompt).toContain("a woman in her 30s");
+      expect(prompt).toContain("Try our mug");
+    });
+
+    it("uses a generic prompt when the character is unknown", async () => {
+      await new VeoProvider("k").generate({ script: "Try our mug", avatarId: "unknown" });
+
+      const prompt = JSON.parse(call().init.body!).instances[0].prompt;
+      expect(prompt).toContain("a person talking directly to camera");
+      expect(prompt).toContain("Try our mug");
+    });
+
+    it("still generates when the character lookup fails", async () => {
+      character.findUnique.mockRejectedValue(new Error("db down"));
+
+      await expect(
+        new VeoProvider("k").generate({ script: "s", avatarId: "c1" })
+      ).resolves.toMatchObject({ status: "queued" });
+    });
+
+    it("surfaces the API error message", async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: { message: "quota exceeded" } }),
+      });
+
+      await expect(
+        new VeoProvider("k").generate({ script: "s", avatarId: "c1" })
+      ).rejects.toThrow("Veo generation error: quota exceeded");
+    });
+
+    it("falls back to the status code when the error body is unreadable", async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => {
+          throw new Error("not json");
+        },
+      });
+
+      await expect(
+        new VeoProvider("k").generate({ script: "s", avatarId: "c1" })
+      ).rejects.toThrow("Veo generation error: 503");
+    });
+
+    it("throws when no operation name comes back", async () => {
+      fetchMock.mockResolvedValue(ok({}));
+      await expect(
+        new VeoProvider("k").generate({ script: "s", avatarId: "c1" })
+      ).rejects.toThrow("Veo did not return an operation name");
+    });
+  });
+
+  describe("getStatus", () => {
+    it("reports processing while the operation is not done", async () => {
+      fetchMock.mockResolvedValue(ok({ done: false }));
+
+      await expect(new VeoProvider("k").getStatus("operations/abc")).resolves.toEqual({
+        videoId: "operations/abc",
+        status: "processing",
+      });
+    });
+
+    it("returns a proxied download URL rather than the raw Google URL", async () => {
+      fetchMock.mockResolvedValue(
+        ok({
+          done: true,
+          response: {
+            generateVideoResponse: {
+              generatedSamples: [
+                { video: { uri: "https://generativelanguage.googleapis.com/v1beta/files/file_123" } },
+              ],
+            },
+          },
+        })
+      );
+
+      const result = await new VeoProvider("k").getStatus("operations/abc");
+
+      expect(result.status).toBe("completed");
+      expect(result.videoUrl).toBe("/api/ugc/download?fileId=file_123");
+      expect(result.videoUrl).not.toContain("googleapis.com");
+    });
+
+    it("reports failure when the operation finishes without a video", async () => {
+      fetchMock.mockResolvedValue(ok({ done: true, response: {} }));
+
+      await expect(new VeoProvider("k").getStatus("operations/abc")).resolves.toEqual({
+        videoId: "operations/abc",
+        status: "failed",
+        error: "Veo completed but returned no video",
+      });
+    });
+
+    it("throws on an API error", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 404 });
+      await expect(new VeoProvider("k").getStatus("operations/abc")).rejects.toThrow(
+        "Veo status error: 404"
+      );
+    });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,33 @@
+import { afterEach, vi } from "vitest";
+
+// Provider modules read configuration from process.env at call time, so every
+// test starts from a known-empty environment rather than inheriting the
+// developer's real .env.
+const PROVIDER_ENV_KEYS = [
+  "LLM_PROVIDER",
+  "IMAGE_PROVIDER",
+  "VIDEO_PROVIDER",
+  "OPENAI_API_KEY",
+  "OPENAI_MODEL",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_MODEL",
+  "GOOGLE_API_KEY",
+  "GEMINI_MODEL",
+  "GEMINI_IMAGE_MODEL",
+  "OLLAMA_BASE_URL",
+  "OLLAMA_MODEL",
+  "STABILITY_API_KEY",
+  "REPLICATE_API_TOKEN",
+  "REPLICATE_MODEL",
+  "HEYGEN_API_KEY",
+  "DID_API_KEY",
+];
+
+for (const key of PROVIDER_ENV_KEYS) {
+  delete process.env[key];
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,28 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Resolves the "@/*" alias straight from tsconfig.json.
+  resolve: { tsconfigPaths: true },
+  test: {
+    // No component tests yet, so the node environment keeps the suite fast.
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    setupFiles: ["tests/setup.ts"],
+    clearMocks: true,
+    restoreMocks: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text-summary", "lcov"],
+      // Thresholds are scoped to the code that holds the logic. Component and
+      // page coverage is deliberately out of scope for now — see README.
+      include: ["src/lib/**/*.ts", "src/app/api/**/*.ts"],
+      exclude: ["src/lib/**/types.ts", "src/lib/db.ts"],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
The project had no tests. This adds **483**, running in about half a second.

```
statements  90.55%   branches  81.05%
functions   94.11%   lines     91.03%
```

## Two access-control bugs, both found while writing the tests

**`POST /api/images/generate` — cross-account write.** The route updated an asset by id alone:

```ts
await requireSession();                                  // result never used
await prisma.asset.update({ where: { id: assetId }, ... })
```

Any signed-in caller could overwrite the `imageUrl` of an asset belonging to **another account** by passing that asset's id. Now scoped through the campaign relation, answering 404 when nothing matched:

```ts
where: { id: assetId, campaign: { userId: session.user.id } }
```

**`PATCH /api/brands/[id]` — mass assignment.** The request body went straight into `prisma.update`, so a caller could set any column — including `userId`, pushing their brand into someone else's account. Now validated against an allowlist with Zod, matching the seven routes that already do this.

Being precise about severity: the brand route *did* check ownership first, so the impact was limited to damaging your own record or planting it on someone else. The asset one genuinely crossed accounts. Neither endpoint has a caller in the UI today.

## Runner

Vitest — ESM-native, no transform config, resolves the `@/` alias straight from `tsconfig`. Node environment, since there are no component tests yet.

## What's covered

| Area | What the tests pin down |
|---|---|
| `brand-dna` | colour extraction (hex/rgb/shorthand/alpha, frequency ordering, the near-white/black filter), font extraction, and the crawler with playwright mocked |
| `campaigns` | prompt building and the generator, including that brand colours reach the image prompt |
| `settings` | user settings over env, per-provider key mapping, and the fallbacks when there is no session or no database |
| `llm` / `image` / `video` | the three provider clients including their module-scope memoisation, plus all eleven concrete providers with SDK or `fetch` mocked |
| `social` | Twitter OAuth 1.0a signing, LinkedIn, Facebook, and the two-step Instagram publish |
| API routes | every route: happy path, signed-out path, and — for anything touching a record — that it is scoped to the signed-in user. SSE routes are driven end to end and their event streams decoded. |

## Coverage gate

Scoped to `src/lib` and `src/app/api`, not the whole tree. A global 80% would demand React component tests to mean anything, and those are separate work — the README now lists them as what comes next. I'd rather have an honest gate on the code that holds the logic than a number propped up by untested UI.

## CI

New `test` job runs `npm run test:coverage`, alongside the existing migrations, entrypoint, build, and compose jobs.

## Two gotchas, documented in CONTRIBUTING

Both cost real time here:

- `beforeEach(() => mock.mockResolvedValue(x))` returns the mock, and **Vitest treats a returned function as a teardown callback** — so it invokes the mock after the test. With `mockRejectedValue` that surfaces as an unhandled rejection attributed to an unrelated line.
- The provider clients memoise at module scope, so tests need `vi.resetModules()` and a re-import between cases.

## Also worth knowing

`extractFonts` returns `fonts.slice(0, 3)` under a comment saying "3 most relevant fonts", but the order is insertion order, not relevance — a heading font discovered fourth is dropped in favour of three body fonts. The test documents current behaviour rather than asserting the comment; worth a follow-up decision.

## Test plan

- [x] `npm test` — 483 passing
- [x] `npm run test:coverage` — all four thresholds met
- [x] `npm run lint`, `npx tsc --noEmit`, `npm run build`
- [x] `sh docker/entrypoint.test.sh`
